### PR TITLE
use main branch for 1.1 dev

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -38,6 +38,18 @@ github:
         dismiss_stale_reviews: false
         require_code_owner_reviews: false
         required_approving_review_count: 1
+    1.0.x:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: false
+        # contexts are the names of checks that must pass
+        contexts:
+          - Code is formatted
+          - Check headers
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1        
 
 notifications:
   commits:              commits@pekko.apache.org

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: 1.0.x
 
       - name: Set up JDK 8
         uses: actions/setup-java@v4

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,6 @@ ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "apache-pekko-projection"
 sourceDistIncubating := false
 
-ThisBuild / pekkoInlineEnabled := false
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 lazy val core =


### PR DESCRIPTION
* protect 1.0.x branch
* use 1.0.x branch to publish 1.0 docs
* enable scala 2 inliner