### PR TITLE
broken java.net links in license report

### DIFF
--- a/scripts/link-validator.conf
+++ b/scripts/link-validator.conf
@@ -54,6 +54,9 @@ site-link-validator {
     "https://github.com/",
     # license report
     "http://stephenc.github.com/jcip-annotations"
+    "http://fi.java.net"
+    "http://stax-ex.java.net/"
+    "https://glassfish.java.net/public/CDDL+GPL_1_1.html"
   ]
 
   non-https-whitelist = [
@@ -62,10 +65,8 @@ site-link-validator {
     "http://creativecommons.org/publicdomain/zero/1.0/"
     "http://dev.mysql.com/doc/connector-j/en/"
     "http://dom4j.github.io/"
-    "http://fi.java.net"
     "http://findbugs.sourceforge.net/"
     "http://github.com/"
-    "http://glassfish.java.net/public/CDDL+GPL_1_1.html"
     "http://hdrhistogram.github.io/HdrHistogram/"
     "http://hibernate.org"
     "http://junit.org"
@@ -73,7 +74,6 @@ site-link-validator {
     "http://www.opensource.org/licenses/"
     "http://repository.jboss.org/licenses/gpl-2.0-ce.txt"
     "http://slick.typesafe.com"
-    "http://stax-ex.java.net/"
     "http://stephenc.github.com/jcip-annotations"
     "http://www.antlr.org/"
     "http://www.apache.org/licenses/"


### PR DESCRIPTION
see https://github.com/apache/pekko-projection/actions/runs/9539525770/job/26289975419?pr=173

I am leaving the cassandra links to a different time.

The license report content is not under our control - all we can do is ignore broken links.

see https://github.com/apache/pekko-projection/issues/160