### PR TITLE
remove incubator footer from docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -202,6 +202,7 @@ lazy val docs = project
     paradoxGroups := Map("Language" -> Seq("Java", "Scala")),
     paradoxRoots := List("index.html", "getting-started/event-generator-app.html"),
     apidocRootPackage := "org.apache.pekko",
+    Global / pekkoParadoxIncubatorNotice := None,
     Compile / paradoxMarkdownToHtml / sourceGenerators += Def.taskDyn {
       val targetFile = (Compile / paradox / sourceManaged).value / "license-report.md"
 


### PR DESCRIPTION
Already set on main branch.

https://github.com/apache/pekko-projection/blob/main/build.sbt#L206

See the footer on https://nightlies.apache.org/pekko/docs/pekko-projection/1.0/docs/
but not on https://nightlies.apache.org/pekko/docs/pekko-projection/1.1/docs/