### PR TITLE
Update protoc to 3.25.5

### DIFF
--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -36,7 +36,7 @@ object Protobuf {
     outputPaths := Seq((Compile / sourceDirectory).value, (Test / sourceDirectory).value).map(_ / "java"),
     importPath := None,
     protoc := "protoc",
-    protocVersion := "3.11.4",
+    protocVersion := "3.25.5",
     generate := {
       val sourceDirs = paths.value
       val targetDirs = outputPaths.value


### PR DESCRIPTION
We have updated to protobuf-java 3.25.5 - seems useful to keep protoc in sync.