### PR TITLE
add ci job to publish 1.0 snapshots and add license headers

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Basic checks
 
 on:

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Update Dependency Graph
 on:
   push:

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Scalafmt
 
 permissions: {}

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Headers
 
 on:

--- a/.github/workflows/integration-tests-cassandra.yml
+++ b/.github/workflows/integration-tests-cassandra.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Integration Tests for Cassandra
 
 on:

--- a/.github/workflows/integration-tests-jdbc.yml
+++ b/.github/workflows/integration-tests-jdbc.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Integration Tests for JDBC
 
 on:

--- a/.github/workflows/integration-tests-kafka.yml
+++ b/.github/workflows/integration-tests-kafka.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Integration Tests for Kafka
 
 on:

--- a/.github/workflows/integration-tests-slick.yml
+++ b/.github/workflows/integration-tests-slick.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Integration Tests for Slick
 
 on:

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Link Validator
 
 permissions: {}

--- a/.github/workflows/nightly-pekko-1.0-tests.yml
+++ b/.github/workflows/nightly-pekko-1.0-tests.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Nightly Integration Tests for JDBC (Pekko 1.0.x)
 
 on:

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Publish 1.0 docs
 
 on:

--- a/.github/workflows/publish-1.0-nightly.yml
+++ b/.github/workflows/publish-1.0-nightly.yml
@@ -15,23 +15,41 @@
 # specific language governing permissions and limitations
 # under the License.
 
+name: Publish 1.0.x Nightly
+
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 * * 0'
-
-name: Launch Scala Steward
+    - cron: "22 0 * * *"
 
 jobs:
-  scala-steward:
-    runs-on: ubuntu-22.04
-    name: Launch Scala Steward
+  publish:
+    # runs on main repo only
     if: github.repository == 'apache/pekko-projection'
+    name: Publish
+    runs-on: ubuntu-22.04
+    env:
+      JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
-      - name: Launch Scala Steward
-        uses: scala-steward-org/scala-steward-action@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          github-app-id: ${{ secrets.SCALA_STEWARD_APP_ID }}
-          github-app-installation-id: ${{ secrets.SCALA_STEWARD_INSTALLATION_ID }}
-          github-app-key: ${{ secrets.SCALA_STEWARD_PRIVATE_KEY }}
-          github-app-auth-only: true
+          # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
+          fetch-depth: 0
+          fetch-tags: true
+          ref: 1.0.x
+
+      - name: Setup Java 8
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 8
+
+      - name: Install sbt
+        uses: sbt/setup-sbt@v1
+
+      - name: Publish to Apache Maven repo
+        env:
+          NEXUS_USER: ${{ secrets.NEXUS_USER }}
+          NEXUS_PW: ${{ secrets.NEXUS_PW }}
+        run: sbt +publish

--- a/.github/workflows/publish-1.1-docs.yml
+++ b/.github/workflows/publish-1.1-docs.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Publish 1.1 docs
 
 on:

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Publish Nightly
 
 on:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,3 +1,11 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# license agreements; and to You under the Apache License, version 2.0:
+#
+#   https://www.apache.org/licenses/LICENSE-2.0
+#
+# This file is part of the Apache Pekko project, which was derived from Akka.
+#
+
 name: Unit Tests
 
 on:


### PR DESCRIPTION
header depends on if the CI job is based on something inherited from Akka or not