### PR TITLE
Fix sequential execution of actor setup in EventSourcedProviderSpec

### DIFF
--- a/eventsourced/src/test/scala/org/apache/pekko/projection/eventsourced/scaldsl/EventSourcedProviderSpec.scala
+++ b/eventsourced/src/test/scala/org/apache/pekko/projection/eventsourced/scaldsl/EventSourcedProviderSpec.scala
@@ -96,7 +96,9 @@ class EventSourcedProviderSpec
       Seq(Some(s"$persistenceId-$event"), maybeJournal).flatten.mkString("-")
     }
     ref ! Command(makeEvent("event-1"), probe.ref)
+    probe.expectMessage(Done)
     ref ! Command(makeEvent("event-2"), probe.ref)
+    probe.expectMessage(Done)
     ref ! Command(makeEvent("event-3"), probe.ref)
     probe.expectMessage(Done)
   }


### PR DESCRIPTION
Resolves https://github.com/apache/pekko-projection/issues/254.

This should be a simple fix for the issue. I think that missing probe calls made it so that setups of different actors got unintentionally executed in parallel, causing their events to get interweaved.

More complex fix for this test, and a one that also better fits how the real implementation of events by slices works, would be to only assert order within persistence ID. We could consider going for that solution now or only if this simpler solution ends up not fixing the issue.