### PR TITLE
protoc 3.25.6

### DIFF
--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -36,7 +36,7 @@ object Protobuf {
     outputPaths := Seq((Compile / sourceDirectory).value, (Test / sourceDirectory).value).map(_ / "java"),
     importPath := None,
     protoc := "protoc",
-    protocVersion := "3.25.5",
+    protocVersion := "3.25.6",
     generate := {
       val sourceDirs = paths.value
       val targetDirs = outputPaths.value


### PR DESCRIPTION
* matches what we have in other pekko repos
* 3.25.6 generated code avoids some problematic code that used to appear when older protoc is used
* follow up to #210