### PR TITLE
Modify .scala-steward.conf for dependency updates

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -2,24 +2,8 @@ updates.ignore = [
 ]
 
 updates.pin = [
-  # Pin logback to v1.3.x because v1.4.x needs JDK11
-  { groupId = "ch.qos.logback", version="1.3." }
-  # Pin hibernate to v5.x because v6.x needs JDK11
-  { groupId = "org.hibernate", version="5." }
-  # use mssql-jdbc Java 8 artifacts
-  { groupId = "com.microsoft.sqlserver", version = { contains = "jre8" } }
-  # Pin h2 to v2.2 because v2.3 needs JDK11
-  { groupId = "com.h2database", version="2.2." }
-
-  # Pin sbt-paradox to v0.9.x because 0.10.x needs JDK 11
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox-project-info", version = "0.9." },
-  { groupId = "com.lightbend.paradox", artifactId = "sbt-paradox", version = "0.9." }
-  # Newer versions need JDK 11 https://github.com/slick/slick/issues/3030
-  { groupId = "com.typesafe.slick", version = "3.5.1"  }
-
-  # https://github.com/apache/pekko/issues/1202
-  { groupId = "com.fasterxml.jackson.core", version="2.17." }
-
+  # use mssql-jdbc Java 11 artifacts
+  { groupId = "com.microsoft.sqlserver", version = { contains = "jre11" } }
   # Scala 3.3 is a LTS
   { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
 ]


### PR DESCRIPTION
Updated configuration to use mssql-jdbc Java 11 artifacts and removed pins for older versions.