### PR TITLE
pin pekko version

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,6 @@
 updates.ignore = [
+  # pekko updates are better handled explicitly
+  { groupId = "org.apache.pekko" }
 ]
 
 updates.pin = [


### PR DESCRIPTION
ScalaSteward is broken because ASF doesn't allow CI jobs to update CI jobs.
https://github.com/apache/pekko-projection/actions/runs/18436628720/job/52530927628#step:3:199

And it just seems tidier for us to decide when the Pekko dependencies change.