### PR TITLE
chore: introduce dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Similar to https://github.com/apache/pekko/blob/main/.github/dependabot.yml

Notably sbt-dependency-submission in
https://github.com/apache/pekko-projection/blob/main/.github/workflows/dependency-graph.yml is outdated