### PR TITLE
fix: handle DeletedDurableState in extractCreationTime implementations

### DIFF
--- a/durable-state/src/main/scala/org/apache/pekko/projection/state/javadsl/DurableStateSourceProvider.scala
+++ b/durable-state/src/main/scala/org/apache/pekko/projection/state/javadsl/DurableStateSourceProvider.scala
@@ -29,6 +29,7 @@ import pekko.annotation.InternalApi
 import pekko.japi.Pair
 import pekko.persistence.query.NoOffset
 import pekko.persistence.query.Offset
+import pekko.persistence.query.DeletedDurableState
 import pekko.persistence.query.DurableStateChange
 import pekko.persistence.query.UpdatedDurableState
 import pekko.persistence.query.javadsl.DurableStateStoreQuery
@@ -79,7 +80,7 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case _                         => 0L // FIXME handle DeletedDurableState when that is added
+        case d: DeletedDurableState[_] => d.timestamp
       }
   }
 
@@ -138,10 +139,7 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case other                     =>
-          // FIXME case DeletedDurableState when that is added
-          throw new IllegalArgumentException(
-            s"DurableStateChange [${other.getClass.getName}] not implemented yet. Please report bug at https://github.com/apache/pekko-persistence-r2dbc/issues")
+        case d: DeletedDurableState[_] => d.timestamp
       }
 
     override def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]] =

--- a/durable-state/src/main/scala/org/apache/pekko/projection/state/scaladsl/DurableStateSourceProvider.scala
+++ b/durable-state/src/main/scala/org/apache/pekko/projection/state/scaladsl/DurableStateSourceProvider.scala
@@ -23,6 +23,7 @@ import pekko.actor.typed.ActorSystem
 import pekko.annotation.ApiMayChange
 import pekko.persistence.query.NoOffset
 import pekko.persistence.query.Offset
+import pekko.persistence.query.DeletedDurableState
 import pekko.persistence.query.DurableStateChange
 import pekko.persistence.query.UpdatedDurableState
 import pekko.persistence.query.scaladsl.DurableStateStoreQuery
@@ -70,7 +71,7 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case _                         => 0L // FIXME handle DeletedDurableState when that is added
+        case d: DeletedDurableState[_] => d.timestamp
       }
   }
 
@@ -127,10 +128,7 @@ object DurableStateSourceProvider {
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
         case u: UpdatedDurableState[_] => u.timestamp
-        case other                     =>
-          // FIXME case DeletedDurableState when that is added
-          throw new IllegalArgumentException(
-            s"DurableStateChange [${other.getClass.getName}] not implemented yet. Please report bug at https://github.com/apache/pekko-persistence-r2dbc/issues")
+        case d: DeletedDurableState[_] => d.timestamp
       }
 
     override def getObject(persistenceId: String): Future[GetObjectResult[A]] =


### PR DESCRIPTION
Part of #350 

Port of https://github.com/akka/akka-projection/pull/723 to pekko-projection.

## Changes

In both `scaladsl/DurableStateSourceProvider` and `javadsl/DurableStateSourceProvider`:

- Added import for `pekko.persistence.query.DeletedDurableState`
- Fixed `extractCreationTime` in `DurableStateStoreQuerySourceProvider` (changesByTag): replaced `case _ => 0L // FIXME` with `case d: DeletedDurableState[_] => d.timestamp`
- Fixed `extractCreationTime` in `DurableStateBySlicesSourceProvider` (changesBySlices): replaced the `throw new IllegalArgumentException(...)` fallback with `case d: DeletedDurableState[_] => d.timestamp`