### PR TITLE
Port akka-projection PR #684: add query plugin instance overloads to source providers

### DIFF
--- a/durable-state/src/main/scala/org/apache/pekko/projection/state/javadsl/DurableStateSourceProvider.scala
+++ b/durable-state/src/main/scala/org/apache/pekko/projection/state/javadsl/DurableStateSourceProvider.scala
@@ -53,7 +53,13 @@ object DurableStateSourceProvider {
     val durableStateStoreQuery =
       DurableStateStoreRegistry(system)
         .getDurableStateStoreFor[DurableStateStoreQuery[A]](classOf[DurableStateStoreQuery[A]], pluginId)
+    changesByTag(system, durableStateStoreQuery, tag)
+  }
 
+  def changesByTag[A](
+      system: ActorSystem[_],
+      durableStateStoreQuery: DurableStateStoreQuery[A],
+      tag: String): SourceProvider[Offset, DurableStateChange[A]] = {
     new DurableStateStoreQuerySourceProvider(durableStateStoreQuery, tag, system)
   }
 
@@ -89,11 +95,18 @@ object DurableStateSourceProvider {
       entityType: String,
       minSlice: Int,
       maxSlice: Int): SourceProvider[Offset, DurableStateChange[A]] = {
-
     val durableStateStoreQuery =
       DurableStateStoreRegistry(system)
         .getDurableStateStoreFor(classOf[DurableStateStoreBySliceQuery[A]], durableStateStoreQueryPluginId)
+    changesBySlices(system, durableStateStoreQuery, entityType, minSlice, maxSlice)
+  }
 
+  def changesBySlices[A](
+      system: ActorSystem[_],
+      durableStateStoreQuery: DurableStateStoreBySliceQuery[A],
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int): SourceProvider[Offset, DurableStateChange[A]] = {
     new DurableStateBySlicesSourceProvider(durableStateStoreQuery, entityType, minSlice, maxSlice, system)
   }
 

--- a/durable-state/src/main/scala/org/apache/pekko/projection/state/scaladsl/DurableStateSourceProvider.scala
+++ b/durable-state/src/main/scala/org/apache/pekko/projection/state/scaladsl/DurableStateSourceProvider.scala
@@ -44,10 +44,15 @@ object DurableStateSourceProvider {
       system: ActorSystem[_],
       pluginId: String,
       tag: String): SourceProvider[Offset, DurableStateChange[A]] = {
-
     val durableStateStoreQuery =
       DurableStateStoreRegistry(system).durableStateStoreFor[DurableStateStoreQuery[A]](pluginId)
+    changesByTag(system, durableStateStoreQuery, tag)
+  }
 
+  def changesByTag[A](
+      system: ActorSystem[_],
+      durableStateStoreQuery: DurableStateStoreQuery[A],
+      tag: String): SourceProvider[Offset, DurableStateChange[A]] = {
     new DurableStateStoreQuerySourceProvider(durableStateStoreQuery, tag, system)
   }
 
@@ -80,11 +85,18 @@ object DurableStateSourceProvider {
       entityType: String,
       minSlice: Int,
       maxSlice: Int): SourceProvider[Offset, DurableStateChange[A]] = {
-
     val durableStateStoreQuery =
       DurableStateStoreRegistry(system)
         .durableStateStoreFor[DurableStateStoreBySliceQuery[A]](durableStateStoreQueryPluginId)
+    changesBySlices(system, durableStateStoreQuery, entityType, minSlice, maxSlice)
+  }
 
+  def changesBySlices[A](
+      system: ActorSystem[_],
+      durableStateStoreQuery: DurableStateStoreBySliceQuery[A],
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int): SourceProvider[Offset, DurableStateChange[A]] = {
     new DurableStateBySlicesSourceProvider(durableStateStoreQuery, entityType, minSlice, maxSlice, system)
   }
 

--- a/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/javadsl/EventSourcedProvider.scala
+++ b/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/javadsl/EventSourcedProvider.scala
@@ -50,11 +50,9 @@ object EventSourcedProvider {
       system: ActorSystem[_],
       readJournalPluginId: String,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
-
     val eventsByTagQuery =
       PersistenceQuery(system).getReadJournalFor(classOf[EventsByTagQuery], readJournalPluginId)
-
-    new EventsByTagSourceProvider(system, eventsByTagQuery, tag)
+    eventsByTag(system, eventsByTagQuery, tag)
   }
 
   def eventsByTag[Event](
@@ -62,10 +60,15 @@ object EventSourcedProvider {
       readJournalPluginId: String,
       readJournalConfig: Config,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
-
     val eventsByTagQuery =
       PersistenceQuery(system).getReadJournalFor(classOf[EventsByTagQuery], readJournalPluginId, readJournalConfig)
+    eventsByTag(system, eventsByTagQuery, tag)
+  }
 
+  def eventsByTag[Event](
+      system: ActorSystem[_],
+      eventsByTagQuery: EventsByTagQuery,
+      tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
     new EventsByTagSourceProvider(system, eventsByTagQuery, tag)
   }
 
@@ -101,21 +104,9 @@ object EventSourcedProvider {
       entityType: String,
       minSlice: Int,
       maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
-
     val eventsBySlicesQuery =
       PersistenceQuery(system).getReadJournalFor(classOf[EventsBySliceQuery], readJournalPluginId)
-
-    if (!eventsBySlicesQuery.isInstanceOf[EventTimestampQuery])
-      throw new IllegalArgumentException(
-        s"[${eventsBySlicesQuery.getClass.getName}] with readJournalPluginId " +
-        s"[$readJournalPluginId] must implement [${classOf[EventTimestampQuery].getName}]")
-
-    if (!eventsBySlicesQuery.isInstanceOf[LoadEventQuery])
-      throw new IllegalArgumentException(
-        s"[${eventsBySlicesQuery.getClass.getName}] with readJournalPluginId " +
-        s"[$readJournalPluginId] must implement [${classOf[LoadEventQuery].getName}]")
-
-    new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+    eventsBySlices(system, eventsBySlicesQuery, entityType, minSlice, maxSlice)
   }
 
   def eventsBySlices[Event](
@@ -125,20 +116,17 @@ object EventSourcedProvider {
       entityType: String,
       minSlice: Int,
       maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
-
     val eventsBySlicesQuery =
       PersistenceQuery(system).getReadJournalFor(classOf[EventsBySliceQuery], readJournalPluginId, readJournalConfig)
+    eventsBySlices(system, eventsBySlicesQuery, entityType, minSlice, maxSlice)
+  }
 
-    if (!eventsBySlicesQuery.isInstanceOf[EventTimestampQuery])
-      throw new IllegalArgumentException(
-        s"[${eventsBySlicesQuery.getClass.getName}] with readJournalPluginId " +
-        s"[$readJournalPluginId] must implement [${classOf[EventTimestampQuery].getName}]")
-
-    if (!eventsBySlicesQuery.isInstanceOf[LoadEventQuery])
-      throw new IllegalArgumentException(
-        s"[${eventsBySlicesQuery.getClass.getName}] with readJournalPluginId " +
-        s"[$readJournalPluginId] must implement [${classOf[LoadEventQuery].getName}]")
-
+  def eventsBySlices[Event](
+      system: ActorSystem[_],
+      eventsBySlicesQuery: EventsBySliceQuery,
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
     new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
   }
 

--- a/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -42,11 +42,9 @@ object EventSourcedProvider {
       system: ActorSystem[_],
       readJournalPluginId: String,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
-
     val eventsByTagQuery =
       PersistenceQuery(system).readJournalFor[EventsByTagQuery](readJournalPluginId)
-
-    new EventsByTagSourceProvider(eventsByTagQuery, tag, system)
+    eventsByTag(system, eventsByTagQuery, tag)
   }
 
   def eventsByTag[Event](
@@ -54,10 +52,15 @@ object EventSourcedProvider {
       readJournalPluginId: String,
       readJournalConfig: Config,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
-
     val eventsByTagQuery =
       PersistenceQuery(system).readJournalFor[EventsByTagQuery](readJournalPluginId, readJournalConfig)
+    eventsByTag(system, eventsByTagQuery, tag)
+  }
 
+  def eventsByTag[Event](
+      system: ActorSystem[_],
+      eventsByTagQuery: EventsByTagQuery,
+      tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
     new EventsByTagSourceProvider(eventsByTagQuery, tag, system)
   }
 
@@ -89,8 +92,7 @@ object EventSourcedProvider {
       maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
     val eventsBySlicesQuery =
       PersistenceQuery(system).readJournalFor[EventsBySliceQuery](readJournalPluginId)
-
-    new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+    eventsBySlices(system, eventsBySlicesQuery, entityType, minSlice, maxSlice)
   }
 
   def eventsBySlices[Event](
@@ -102,7 +104,15 @@ object EventSourcedProvider {
       maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
     val eventsBySlicesQuery =
       PersistenceQuery(system).readJournalFor[EventsBySliceQuery](readJournalPluginId, readJournalConfig)
+    eventsBySlices(system, eventsBySlicesQuery, entityType, minSlice, maxSlice)
+  }
 
+  def eventsBySlices[Event](
+      system: ActorSystem[_],
+      eventsBySlicesQuery: EventsBySliceQuery,
+      entityType: String,
+      minSlice: Int,
+      maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
     new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
   }
 


### PR DESCRIPTION
Part of https://github.com/apache/pekko-projection/issues/350

Ports https://github.com/akka/akka-projection/pull/684 to pekko-projection.

Adds "power user API" overloads that accept a query plugin instance directly (instead of a plugin ID string). This allows users with custom configuration or programmatic setup of query plugins to pass in the query instance directly, without going through the registry lookup by plugin ID.

## Changes

- **scaladsl/EventSourcedProvider**: added `eventsByTag(system, EventsByTagQuery, tag)` and `eventsBySlices(system, EventsBySliceQuery, ...)` overloads; existing `pluginId`-based overloads now delegate to these
- **javadsl/EventSourcedProvider**: same as scaladsl; also removed leftover `isInstanceOf` checks that were already present only in javadsl (never in scaladsl) and were made redundant by graceful pattern matching inside the provider — as noted by the original PR author
- **scaladsl/DurableStateSourceProvider**: added `changesByTag(system, DurableStateStoreQuery, tag)` and `changesBySlices(system, DurableStateStoreBySliceQuery, ...)` overloads
- **javadsl/DurableStateSourceProvider**: same as scaladsl