### PR TITLE
fix: move latch.countDown() after buffer.append() in concatHandler to fix race condition

### DIFF
--- a/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
+++ b/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
@@ -217,11 +217,12 @@ public class JdbcProjectionTest extends JUnitSuite {
       StringBuffer buffer, CountDownLatch latch, Predicate<Long> failPredicate) {
     return JdbcHandler.fromFunction(
         (PureJdbcSession session, Envelope envelope) -> {
-          latch.countDown();
           if (failPredicate.test(envelope.offset)) {
+            latch.countDown();
             throw new RuntimeException(failMessage(envelope.offset));
           } else {
             buffer.append(envelope.message).append("|");
+            latch.countDown();
           }
         });
   }


### PR DESCRIPTION
fixes #104 

`atLeastOnceShouldRestartFromPreviousOffset` was intermittently failing with `expected:<abc|def|[ghi|]> but was:<abc|def|[]>` due to a race condition in `concatHandler`.

`latch.countDown()` was called *before* `buffer.append()`, so when offset 3 unblocked the test thread (latch → 0), `"ghi|"` hadn't been written to the buffer yet.

**Fix:** reorder operations so `latch.countDown()` fires only after the buffer is updated:

```java
// Before
latch.countDown();
if (failPredicate.test(envelope.offset)) {
    throw new RuntimeException(...);
} else {
    buffer.append(envelope.message).append("|");
}

// After
if (failPredicate.test(envelope.offset)) {
    latch.countDown();
    throw new RuntimeException(...);
} else {
    buffer.append(envelope.message).append("|");
    latch.countDown();
}
```