### PR TITLE
Port CanTriggerReplay and ScalaBySlicesSourceProviderAdapter from akka-projection 1.4.x

### DIFF
--- a/core/src/main/scala/org/apache/pekko/projection/internal/CanTriggerReplay.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/CanTriggerReplay.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+/*
+ * Copyright (C) 2009-2023 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package org.apache.pekko.projection.internal
+
+import org.apache.pekko.annotation.InternalApi
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[pekko] trait CanTriggerReplay {
+  private[pekko] def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit
+}

--- a/core/src/main/scala/org/apache/pekko/projection/internal/SourceProviderAdapter.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/SourceProviderAdapter.scala
@@ -24,9 +24,11 @@ import scala.jdk.OptionConverters._
 import org.apache.pekko
 import pekko.NotUsed
 import pekko.annotation.InternalApi
+import pekko.projection.BySlicesSourceProvider
 import pekko.projection.javadsl
 import pekko.projection.scaladsl
 import pekko.stream.scaladsl.Source
+import pekko.stream.javadsl.{ Source => JSource }
 
 /**
  * INTERNAL API: Adapter from javadsl.SourceProvider to scaladsl.SourceProvider
@@ -48,4 +50,28 @@ import pekko.stream.scaladsl.Source
   def extractOffset(envelope: Envelope): Offset = delegate.extractOffset(envelope)
 
   def extractCreationTime(envelope: Envelope): Long = delegate.extractCreationTime(envelope)
+}
+
+/**
+ * INTERNAL API: Adapter from scaladsl.SourceProvider with BySlicesSourceProvider to javadsl.SourceProvider with BySlicesSourceProvider
+ */
+@InternalApi private[projection] class ScalaBySlicesSourceProviderAdapter[Offset, Envelope](
+    delegate: scaladsl.SourceProvider[Offset, Envelope] with BySlicesSourceProvider)
+    extends javadsl.SourceProvider[Offset, Envelope]
+    with BySlicesSourceProvider {
+  override def source(
+      offset: Supplier[CompletionStage[Optional[Offset]]])
+      : CompletionStage[JSource[Envelope, NotUsed]] =
+    delegate
+      .source(() => offset.get().asScala.map(_.toScala)(ExecutionContext.parasitic))
+      .map(_.asJava)(ExecutionContext.parasitic)
+      .asJava
+
+  override def extractOffset(envelope: Envelope): Offset = delegate.extractOffset(envelope)
+
+  override def extractCreationTime(envelope: Envelope): Long = delegate.extractCreationTime(envelope)
+
+  def minSlice: Int = delegate.minSlice
+
+  def maxSlice: Int = delegate.maxSlice
 }

--- a/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/javadsl/EventSourcedProvider.scala
+++ b/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/javadsl/EventSourcedProvider.scala
@@ -39,6 +39,7 @@ import pekko.persistence.query.typed.javadsl.EventsBySliceQuery
 import pekko.persistence.query.typed.javadsl.LoadEventQuery
 import pekko.projection.BySlicesSourceProvider
 import pekko.projection.eventsourced.EventEnvelope
+import pekko.projection.internal.CanTriggerReplay
 import pekko.projection.javadsl
 import pekko.projection.javadsl.SourceProvider
 import pekko.stream.javadsl.Source
@@ -127,7 +128,16 @@ object EventSourcedProvider {
       entityType: String,
       minSlice: Int,
       maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
-    new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+    eventsBySlicesQuery match {
+      case query: EventsBySliceQuery with CanTriggerReplay =>
+        new EventsBySlicesSourceProvider[Event](eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+          with CanTriggerReplay {
+          private[pekko] override def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
+            query.triggerReplay(persistenceId, fromSeqNr)
+        }
+      case _ =>
+        new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+    }
   }
 
   def sliceForPersistenceId(system: ActorSystem[_], readJournalPluginId: String, persistenceId: String): Int =

--- a/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -32,6 +32,7 @@ import pekko.persistence.query.typed.scaladsl.EventsBySliceQuery
 import pekko.persistence.query.typed.scaladsl.LoadEventQuery
 import pekko.projection.BySlicesSourceProvider
 import pekko.projection.eventsourced.EventEnvelope
+import pekko.projection.internal.CanTriggerReplay
 import pekko.projection.scaladsl.SourceProvider
 import pekko.stream.scaladsl.Source
 
@@ -113,7 +114,16 @@ object EventSourcedProvider {
       entityType: String,
       minSlice: Int,
       maxSlice: Int): SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]] = {
-    new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+    eventsBySlicesQuery match {
+      case query: EventsBySliceQuery with CanTriggerReplay =>
+        new EventsBySlicesSourceProvider[Event](eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+          with CanTriggerReplay {
+          private[pekko] override def triggerReplay(persistenceId: String, fromSeqNr: Long): Unit =
+            query.triggerReplay(persistenceId, fromSeqNr)
+        }
+      case _ =>
+        new EventsBySlicesSourceProvider(eventsBySlicesQuery, entityType, minSlice, maxSlice, system)
+    }
   }
 
   def sliceForPersistenceId(system: ActorSystem[_], readJournalPluginId: String, persistenceId: String): Int =


### PR DESCRIPTION
Now available under Apache License v2.0.

Ports the non-grpc, non-r2dbc changes from [pjfanning/akka-projection](https://github.com/pjfanning/akka-projection) (1.4.x branch, SHA `90dbc3a4`) that were missing from this repo.

## Changes

### New file: `core/.../projection/internal/CanTriggerReplay.scala`
A new internal trait that allows a projection source provider (specifically an `EventsBySliceQuery`) to signal that it supports replay triggering for a given persistence ID and sequence number. Used by `EventSourcedProvider` factories when the underlying query supports it.

### `core/.../projection/internal/SourceProviderAdapter.scala`
Added `ScalaBySlicesSourceProviderAdapter` — adapts a Scala DSL `SourceProvider with BySlicesSourceProvider` to the Java DSL interface. Without this, a slice-based source created via the Scala API could not be bridged to the Java API.

### `eventsourced/.../scaladsl/EventSourcedProvider.scala`
The `eventsBySlices` factory that accepts a raw query now checks whether the query implements `CanTriggerReplay`. If so, the returned `SourceProvider` also mixes in `CanTriggerReplay`, delegating to the query — enabling downstream consumers (e.g. offset stores) to trigger event replay for specific persistence IDs.

### `eventsourced/.../javadsl/EventSourcedProvider.scala`
Same `CanTriggerReplay` mixin wired in for the Java API counterpart.

## What was intentionally skipped
- **gRPC and R2DBC modules** — excluded per requirements (changes are large)
- **Scala 3 compatibility changes** (`ProjectionContextImpl` private constructor + `withGroupSize`) — already present in this repo

Agent-Logs-Url: https://github.com/pjfanning/incubator-pekko-projection/sessions/5ed34547-44f6-4f51-ad38-2ce0babfb1be