### PR TITLE
grpc: better support Protobuf Message

### DIFF
--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
@@ -246,23 +246,13 @@ import scalapb.options.Scalapb
     }
   }
 
-  private def hasExtension[ContainerT <: PBGeneratedMessage.ExtendableMessage[ContainerT], T](
-      msg: PBGeneratedMessage.ExtendableMessageOrBuilder[ContainerT],
-      ext: PBGeneratedMessage.GeneratedExtension[ContainerT, T]
-  ): Boolean = msg.hasExtension(ext)
-
-  private def getExtension[ContainerT <: PBGeneratedMessage.ExtendableMessage[ContainerT], T](
-      msg: PBGeneratedMessage.ExtendableMessageOrBuilder[ContainerT],
-      ext: PBGeneratedMessage.GeneratedExtension[ContainerT, T]
-  ): T = msg.getExtension(ext)
-
   private def tryResolveScalaPbType(typeDescriptor: Descriptors.Descriptor): Option[ScalaPbResolvedType[Nothing]] = {
     // todo - attempt to load the package.proto file for this package to get default options from there
     val fileDescriptor = typeDescriptor.getFile
     val options = fileDescriptor.getOptions
     val scalaOptions: Scalapb.ScalaPbOptions =
-      if (hasExtension(options, Scalapb.options)) {
-        getExtension(options, Scalapb.options)
+      if (options.hasExtension(Scalapb.options)) {
+        options.getExtension(Scalapb.options)
       } else Scalapb.ScalaPbOptions.getDefaultInstance
 
     // Firstly, determine the java package

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
@@ -27,15 +27,13 @@ import pekko.serialization.Serializers
 import com.google.common.base.CaseFormat
 import com.google.protobuf.ByteString
 import com.google.protobuf.Descriptors
-import com.google.protobuf.GeneratedMessageV3
+import com.google.protobuf.{ GeneratedMessage => PBGeneratedMessage }
 import com.google.protobuf.Message
 import com.google.protobuf.Parser
 import com.google.protobuf.any.{ Any => ScalaPbAny }
 import com.google.protobuf.{ Any => JavaPbAny }
 import com.google.protobuf.{ Any => PbAny }
 import org.slf4j.LoggerFactory
-import scalapb.GeneratedMessage
-import scalapb.GeneratedMessageCompanion
 import scalapb.options.Scalapb
 
 /**
@@ -140,7 +138,7 @@ import scalapb.options.Scalapb
       case pbAny: PbAny                  => ScalaPbAny.fromJavaProto(pbAny)
       case msg: scalapb.GeneratedMessage =>
         encode(msg)
-      case msg: GeneratedMessageV3 =>
+      case msg: PBGeneratedMessage =>
         encode(msg)
       case other =>
         // fallback to Pekko serialization
@@ -248,13 +246,23 @@ import scalapb.options.Scalapb
     }
   }
 
+  private def hasExtension[ContainerT <: PBGeneratedMessage.ExtendableMessage[ContainerT], T](
+      msg: PBGeneratedMessage.ExtendableMessageOrBuilder[ContainerT],
+      ext: PBGeneratedMessage.GeneratedExtension[ContainerT, T]
+  ): Boolean = msg.hasExtension(ext)
+
+  private def getExtension[ContainerT <: PBGeneratedMessage.ExtendableMessage[ContainerT], T](
+      msg: PBGeneratedMessage.ExtendableMessageOrBuilder[ContainerT],
+      ext: PBGeneratedMessage.GeneratedExtension[ContainerT, T]
+  ): T = msg.getExtension(ext)
+
   private def tryResolveScalaPbType(typeDescriptor: Descriptors.Descriptor): Option[ScalaPbResolvedType[Nothing]] = {
     // todo - attempt to load the package.proto file for this package to get default options from there
     val fileDescriptor = typeDescriptor.getFile
     val options = fileDescriptor.getOptions
     val scalaOptions: Scalapb.ScalaPbOptions =
-      if (options.hasExtension(Scalapb.options)) {
-        options.getExtension(Scalapb.options)
+      if (hasExtension(options, Scalapb.options)) {
+        getExtension(options, Scalapb.options)
       } else Scalapb.ScalaPbOptions.getDefaultInstance
 
     // Firstly, determine the java package
@@ -280,7 +288,7 @@ import scalapb.options.Scalapb
       try {
         log.debug("Attempting to load scalapb.GeneratedMessageCompanion object {}", className)
         val companionObject =
-          system.dynamicAccess.getObjectFor[GeneratedMessageCompanion[GeneratedMessage]](className).get
+          system.dynamicAccess.getObjectFor[scalapb.GeneratedMessageCompanion[scalapb.GeneratedMessage]](className).get
         Some(new ScalaPbResolvedType(companionObject))
       } catch {
         case cnfe: ClassNotFoundException =>
@@ -327,7 +335,7 @@ import scalapb.options.Scalapb
           GoogleTypeUrlPrefix + javaProtoMessage.getDescriptorForType.getFullName,
           javaProtoMessage.toByteString)
 
-      case scalaPbMessage: GeneratedMessage =>
+      case scalaPbMessage: scalapb.GeneratedMessage =>
         ScalaPbAny(GoogleTypeUrlPrefix + scalaPbMessage.companion.scalaDescriptor.fullName, scalaPbMessage.toByteString)
 
       case null =>

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
@@ -27,7 +27,6 @@ import pekko.serialization.Serializers
 import com.google.common.base.CaseFormat
 import com.google.protobuf.ByteString
 import com.google.protobuf.Descriptors
-import com.google.protobuf.{ GeneratedMessage => PBGeneratedMessage }
 import com.google.protobuf.Message
 import com.google.protobuf.Parser
 import com.google.protobuf.any.{ Any => ScalaPbAny }
@@ -138,7 +137,7 @@ import scalapb.options.Scalapb
       case pbAny: PbAny                  => ScalaPbAny.fromJavaProto(pbAny)
       case msg: scalapb.GeneratedMessage =>
         encode(msg)
-      case msg: PBGeneratedMessage =>
+      case msg: com.google.protobuf.Message =>
         encode(msg)
       case other =>
         // fallback to Pekko serialization


### PR DESCRIPTION
GeneratedMessageV3 is deprecated in most recent Protobuf releases and it implements com.google.protobuf.Message
as does GeneratedMessage which is taking over from GeneratedMessageV3

https://javadoc.io/doc/com.google.protobuf/protobuf-java/3.25.8/com/google/protobuf/GeneratedMessageV3.html
https://javadoc.io/doc/com.google.protobuf/protobuf-java/3.25.8/com/google/protobuf/GeneratedMessage.html

The encode method in ProtoAnySerialization already handles com.google.protobuf.Message internally so it seems wasteful not to direct all messages that implement com.google.protobuf.Message to encode.
