### PR TITLE
Add -Yfuture-lazy-vals for Scala 3.3.x builds

### DIFF
--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -44,6 +44,8 @@ object PekkoDisciplinePlugin extends AutoPlugin {
                 "-Xlint:-strict-unsealed-patmat",
                 // scala/bug#7014 is a false positive compiler warning affecting r2dbc-spi jar loading
                 "-Wconf:msg=scala/bug#7014:s")
+            case Some((3, _)) =>
+              Set("-Yfuture-lazy-vals")
             case _ =>
               Nil
           }).toSeq,

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -45,7 +45,7 @@ object PekkoDisciplinePlugin extends AutoPlugin {
                 // scala/bug#7014 is a false positive compiler warning affecting r2dbc-spi jar loading
                 "-Wconf:msg=scala/bug#7014:s")
             case Some((3, _)) =>
-              Set("-Yfuture-lazy-vals")
+              Set("-Yfuture-lazy-vals", "-release:17")
             case _ =>
               Nil
           }).toSeq,


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

Add `-Yfuture-lazy-vals` to scalacOptions, conditionally applied only for Scala 3.3.x.

### Result

Scala 3.3.x build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions including future releases that restrict `sun.misc.Unsafe`.

### References

Refs scala/scala3-lts#637
Refs apache/pekko#3059