### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -75,3 +75,13 @@ project.excludeFilters = [
   "scripts/authors.scala"
 ]
 project.layout         = StandardConvention
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/CassandraProjectionSpec.scala
+++ b/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/CassandraProjectionSpec.scala
@@ -189,7 +189,7 @@ class CassandraProjectionSpec
   private def genRandomProjectionId() =
     ProjectionId(UUID.randomUUID().toString, UUID.randomUUID().toString)
 
-  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[_]): Throwable = {
+  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[?]): Throwable = {
     sinkProbe.expectNextOrError() match {
       case Right(_)  => eventuallyExpectError(sinkProbe)
       case Left(exc) => exc

--- a/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/internal/CassandraOffsetStore.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/internal/CassandraOffsetStore.scala
@@ -36,7 +36,7 @@ import com.datastax.oss.driver.api.core.cql.Statement
 /**
  * INTERNAL API
  */
-@InternalApi private[projection] class CassandraOffsetStore(system: ActorSystem[_], clock: Clock) {
+@InternalApi private[projection] class CassandraOffsetStore(system: ActorSystem[?], clock: Clock) {
   private val offsetSerialization = new OffsetSerialization(system)
   import offsetSerialization.fromStorageRepresentation
   import offsetSerialization.toStorageRepresentation
@@ -51,7 +51,7 @@ import com.datastax.oss.driver.api.core.cql.Statement
   val managementTable: String = cassandraSettings.managementTable
   private val cassandraPartitions = 5
 
-  def this(system: ActorSystem[_]) =
+  def this(system: ActorSystem[?]) =
     this(system, Clock.systemUTC())
 
   private def selectOne[T <: Statement[T]](stmt: Statement[T]): Future[Option[Row]] = {
@@ -79,7 +79,7 @@ import com.datastax.oss.driver.api.core.cql.Statement
     // same time let us query all rows for a single projection_name easily
     val partition = idToPartition(projectionId)
     offset match {
-      case _: MergeableOffset[_] =>
+      case _: MergeableOffset[?] =>
         throw new IllegalArgumentException("The CassandraOffsetStore does not currently support MergeableOffset")
       case _ =>
         val SingleOffset(_, manifest, offsetStr, _) =

--- a/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/internal/CassandraProjectionImpl.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/internal/CassandraProjectionImpl.scala
@@ -87,7 +87,7 @@ import pekko.stream.scaladsl.Source
   /*
    * Build the final ProjectionSettings to use, if currently set to None fallback to values in config file
    */
-  private def settingsOrDefaults(implicit system: ActorSystem[_]): ProjectionSettings = {
+  private def settingsOrDefaults(implicit system: ActorSystem[?]): ProjectionSettings = {
     val settings = settingsOpt.getOrElse(ProjectionSettings(system))
     restartBackoffOpt match {
       case None    => settings
@@ -158,7 +158,7 @@ import pekko.stream.scaladsl.Source
    * Return a RunningProjection
    */
   @InternalApi
-  override private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection = {
+  override private[projection] def run()(implicit system: ActorSystem[?]): RunningProjection = {
     new CassandraInternalProjectionState(settingsOrDefaults).newRunningInstance()
   }
 
@@ -169,7 +169,7 @@ import pekko.stream.scaladsl.Source
    * This is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
   @InternalApi
-  override private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] = {
+  override private[projection] def mappedSource()(implicit system: ActorSystem[?]): Source[Done, Future[Done]] = {
     new CassandraInternalProjectionState(settingsOrDefaults).mappedSource()
   }
 
@@ -178,7 +178,7 @@ import pekko.stream.scaladsl.Source
    * This internal class will hold the KillSwitch that is needed
    * when building the mappedSource and when running the projection (to stop)
    */
-  private class CassandraInternalProjectionState(val settings: ProjectionSettings)(implicit val system: ActorSystem[_])
+  private class CassandraInternalProjectionState(val settings: ProjectionSettings)(implicit val system: ActorSystem[?])
       extends InternalProjectionState[Offset, Envelope](
         projectionId,
         sourceProvider,
@@ -210,9 +210,9 @@ import pekko.stream.scaladsl.Source
   }
 
   private class CassandraRunningProjection(
-      source: Source[Done, _],
+      source: Source[Done, ?],
       offsetStore: CassandraOffsetStore,
-      projectionState: CassandraInternalProjectionState)(implicit system: ActorSystem[_])
+      projectionState: CassandraInternalProjectionState)(implicit system: ActorSystem[?])
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 

--- a/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/internal/CassandraSettings.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/internal/CassandraSettings.scala
@@ -36,6 +36,6 @@ private[projection] case class CassandraSettings(config: Config) {
 @InternalApi
 private[projection] object CassandraSettings {
 
-  def apply(system: ActorSystem[_]): CassandraSettings =
+  def apply(system: ActorSystem[?]): CassandraSettings =
     CassandraSettings(system.settings.config.getConfig("pekko.projection.cassandra"))
 }

--- a/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/javadsl/CassandraProjection.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/javadsl/CassandraProjection.scala
@@ -120,7 +120,7 @@ object CassandraProjection {
   def atLeastOnceFlow[Offset, Envelope](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _])
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?])
       : AtLeastOnceFlowProjection[Offset, Envelope] =
     new CassandraProjectionImpl(
       projectionId,
@@ -154,7 +154,7 @@ object CassandraProjection {
    * For production it's recommended to create the table with DDL statements
    * before the system is started.
    */
-  def createTablesIfNotExists(system: ActorSystem[_]): CompletionStage[Done] = {
+  def createTablesIfNotExists(system: ActorSystem[?]): CompletionStage[Done] = {
     import scala.jdk.FutureConverters._
     val offsetStore = new CassandraOffsetStore(system)
     offsetStore.createKeyspaceAndTable().asJava

--- a/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -122,7 +122,7 @@ object CassandraProjection {
   def atLeastOnceFlow[Offset, Envelope](
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _])
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?])
       : AtLeastOnceFlowProjection[Offset, Envelope] =
     new CassandraProjectionImpl(
       projectionId,
@@ -156,7 +156,7 @@ object CassandraProjection {
    * For production, it's recommended to create the table with DDL statements
    * before the system is started.
    */
-  def createTablesIfNotExists()(implicit system: ActorSystem[_]): Future[Done] = {
+  def createTablesIfNotExists()(implicit system: ActorSystem[?]): Future[Done] = {
     val offsetStore = new CassandraOffsetStore(system)
     offsetStore.createKeyspaceAndTable()
   }

--- a/core-test/src/test/scala/org/apache/pekko/projection/ProjectionBehaviorSpec.scala
+++ b/core-test/src/test/scala/org/apache/pekko/projection/ProjectionBehaviorSpec.scala
@@ -101,7 +101,7 @@ object ProjectionBehaviorSpec {
         () => new TestInMemoryOffsetStoreImpl[Int](),
         None) {
 
-    override private[projection] def newState(implicit system: ActorSystem[_]): TestInternalProjectionState[Int, Int] =
+    override private[projection] def newState(implicit system: ActorSystem[?]): TestInternalProjectionState[Int, Int] =
       new ProjectionBehaviourTestInternalProjectionState(
         projectionId,
         sourceProvider,
@@ -120,7 +120,7 @@ object ProjectionBehaviorSpec {
         statusObserver: StatusObserver[Int],
         offsetStore: TestOffsetStore[Int],
         testProbe: TestProbe[ProbeMessage],
-        failToStop: Boolean)(implicit system: ActorSystem[_])
+        failToStop: Boolean)(implicit system: ActorSystem[?])
         extends TestInternalProjectionState[Int, Int](
           projectionId,
           sourceProvider,
@@ -141,11 +141,11 @@ object ProjectionBehaviorSpec {
 
     private[projection] class ProjectionBehaviourTestRunningProjection(
         projectionId: ProjectionId,
-        source: Source[Done, _],
+        source: Source[Done, ?],
         killSwitch: SharedKillSwitch,
         offsetStore: TestOffsetStore[Int],
         testProbe: TestProbe[ProbeMessage],
-        failToStop: Boolean)(implicit _system: ActorSystem[_])
+        failToStop: Boolean)(implicit _system: ActorSystem[?])
         extends TestRunningProjection(source, killSwitch)
         with RunningProjectionManagement[Int] {
       import system.executionContext

--- a/core-test/src/test/scala/org/apache/pekko/projection/internal/TelemetryProviderSpec.scala
+++ b/core-test/src/test/scala/org/apache/pekko/projection/internal/TelemetryProviderSpec.scala
@@ -86,7 +86,7 @@ class TelemetryProviderEnsembleSpec extends ScalaTestWithActorTestKit(s"""
 object FakeTelemetry {
   val state = new AtomicReference[String]("")
 }
-class FakeTelemetry(projectionId: ProjectionId, system: ActorSystem[_]) extends Telemetry {
+class FakeTelemetry(projectionId: ProjectionId, system: ActorSystem[?]) extends Telemetry {
 
   override def failed(cause: Throwable): Unit = {}
 

--- a/core-test/src/test/scala/org/apache/pekko/projection/internal/metrics/tools/InMemTelemetry.scala
+++ b/core-test/src/test/scala/org/apache/pekko/projection/internal/metrics/tools/InMemTelemetry.scala
@@ -30,7 +30,7 @@ import pekko.projection.internal.Telemetry
 
 /**
  */
-class InMemTelemetry(projectionId: ProjectionId, system: ActorSystem[_]) extends Telemetry {
+class InMemTelemetry(projectionId: ProjectionId, system: ActorSystem[?]) extends Telemetry {
   private val instruments: InMemInstruments = InMemInstrumentsRegistry(system).forId(projectionId)
 
   import instruments._
@@ -74,9 +74,9 @@ case class ExternalContext(readyTimestampNanos: Long = System.nanoTime())
 case object TelemetryException extends RuntimeException("Oh, no! Handler errored.") with NoStackTrace
 
 object InMemInstrumentsRegistry extends ExtensionId[InMemInstrumentsRegistry] {
-  override def createExtension(system: ActorSystem[_]): InMemInstrumentsRegistry = new InMemInstrumentsRegistry(system)
+  override def createExtension(system: ActorSystem[?]): InMemInstrumentsRegistry = new InMemInstrumentsRegistry(system)
 }
-class InMemInstrumentsRegistry(system: ActorSystem[_]) extends Extension {
+class InMemInstrumentsRegistry(system: ActorSystem[?]) extends Extension {
   private val instrumentMap = new ConcurrentHashMap[ProjectionId, InMemInstruments]()
   def forId(projectionId: ProjectionId): InMemInstruments = {
     instrumentMap.computeIfAbsent(projectionId,
@@ -86,7 +86,7 @@ class InMemInstrumentsRegistry(system: ActorSystem[_]) extends Extension {
   }
 
   // these are added to use the constructor argument and keep the AkkaDisciplinePlugin happy
-  val observedActorSystem = new AtomicReference[ActorSystem[_]](null)
+  val observedActorSystem = new AtomicReference[ActorSystem[?]](null)
   observedActorSystem.set(system)
 }
 

--- a/core-test/src/test/scala/org/apache/pekko/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
+++ b/core-test/src/test/scala/org/apache/pekko/projection/internal/metrics/tools/InternalProjectionStateMetricsSpec.scala
@@ -83,7 +83,7 @@ abstract class InternalProjectionStateMetricsSpec
 
   // inspired on ProjectionTestkit's runInternal
   protected def runInternal(
-      projectionState: InMemInternalProjectionState[_, _],
+      projectionState: InMemInternalProjectionState[?, ?],
       max: FiniteDuration = 3.seconds,
       interval: FiniteDuration = 100.millis)(assertFunction: => Unit): Unit = {
 
@@ -135,7 +135,7 @@ object InternalProjectionStateMetricsSpec {
       handlerStrategy: HandlerStrategy,
       numberOfEnvelopes: Int = 6,
       statusObserver: StatusObserver[Envelope] = NoopStatusObserver)(
-      implicit system: ActorSystem[_],
+      implicit system: ActorSystem[?],
       projectionId: ProjectionId) {
 
     private implicit val exCtx: ExecutionContext = system.executionContext
@@ -196,7 +196,7 @@ object InternalProjectionStateMetricsSpec {
       handlerStrategy: HandlerStrategy,
       statusObserver: StatusObserver[Env],
       settings: ProjectionSettings,
-      offsetStore: TestInMemoryOffsetStoreImpl[Offset])(implicit val system: ActorSystem[_])
+      offsetStore: TestInMemoryOffsetStoreImpl[Offset])(implicit val system: ActorSystem[?])
       extends InternalProjectionState[Offset, Env](
         projectionId,
         sourceProvider,
@@ -220,7 +220,7 @@ object InternalProjectionStateMetricsSpec {
     def newRunningInstance(): RunningProjection =
       new TestRunningProjection(RunningProjection.withBackoff(() => mappedSource(), settings), killSwitch)
 
-    class TestRunningProjection(val source: Source[Done, _], killSwitch: SharedKillSwitch) extends RunningProjection {
+    class TestRunningProjection(val source: Source[Done, ?], killSwitch: SharedKillSwitch) extends RunningProjection {
 
       private val futureDone = source.run()
 

--- a/core/src/main/scala/org/apache/pekko/projection/Projection.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/Projection.scala
@@ -83,7 +83,7 @@ trait Projection[Envelope] {
    * This is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
   @InternalApi
-  private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]]
+  private[projection] def mappedSource()(implicit system: ActorSystem[?]): Source[Done, Future[Done]]
 
   /**
    * INTERNAL API
@@ -95,7 +95,7 @@ trait Projection[Envelope] {
    * Return a RunningProjection
    */
   @InternalApi
-  private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection
+  private[projection] def run()(implicit system: ActorSystem[?]): RunningProjection
 
 }
 
@@ -112,7 +112,7 @@ private[projection] object RunningProjection {
    */
   case object AbortProjectionException extends RuntimeException("Projection aborted.") with NoStackTrace
 
-  def withBackoff(source: () => Source[Done, _], settings: ProjectionSettings): Source[Done, _] = {
+  def withBackoff(source: () => Source[Done, ?], settings: ProjectionSettings): Source[Done, ?] = {
     RestartSource
       .onFailuresWithBackoff(settings.restartBackoff) { () =>
         source()

--- a/core/src/main/scala/org/apache/pekko/projection/ProjectionBehavior.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/ProjectionBehavior.scala
@@ -85,7 +85,7 @@ object ProjectionBehavior {
           ctx.log.debug2("Started actor handler [{}] for projection [{}]", ref, projection.projectionId)
         }
         val running = projection.run()(ctx.system)
-        if (running.isInstanceOf[RunningProjectionManagement[_]])
+        if (running.isInstanceOf[RunningProjectionManagement[?]])
           ProjectionManagement(ctx.system).register(projection.projectionId, ctx.self)
         new ProjectionBehavior[Any, Envelope](ctx, projection, stashBuffer).started(running)
       }
@@ -155,7 +155,7 @@ object ProjectionBehavior {
 
         case isPaused: IsPaused =>
           running match {
-            case mgmt: RunningProjectionManagement[_] =>
+            case mgmt: RunningProjectionManagement[?] =>
               if (isPaused.projectionId == projectionId) {
                 context.pipeToSelf(mgmt.getManagementState()) {
                   case Success(state) => GetManagementStateResult(state, isPaused.replyTo)
@@ -172,7 +172,7 @@ object ProjectionBehavior {
 
         case setPaused: SetPaused =>
           running match {
-            case mgmt: RunningProjectionManagement[_] =>
+            case mgmt: RunningProjectionManagement[?] =>
               if (setPaused.projectionId == projectionId) {
                 context.log.info2(
                   "Running state will be changed to [{}] for projection [{}].",
@@ -246,7 +246,7 @@ object ProjectionBehavior {
     Behaviors.same
   }
 
-  private def settingPaused(setPaused: SetPaused, mgmt: RunningProjectionManagement[_]): Behavior[Command] =
+  private def settingPaused(setPaused: SetPaused, mgmt: RunningProjectionManagement[?]): Behavior[Command] =
     Behaviors.receiveMessage {
       case Stopped =>
         context.log.debug("Projection [{}] stopped", projectionId)

--- a/core/src/main/scala/org/apache/pekko/projection/internal/HandlerRecoveryImpl.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/HandlerRecoveryImpl.scala
@@ -66,7 +66,7 @@ import pekko.projection.StatusObserver
       lastOffset: Offset, // used for logging
       abort: Future[Done], // retries can be aborted by failing this Future
       futureCallback: () => Future[Done],
-      onSkip: () => Future[Done] = HandlerRecoveryImpl.defaultOnSkip)(implicit system: ActorSystem[_]): Future[Done] = {
+      onSkip: () => Future[Done] = HandlerRecoveryImpl.defaultOnSkip)(implicit system: ActorSystem[?]): Future[Done] = {
     import HandlerRecoveryStrategy.Internal._
 
     implicit val scheduler: Scheduler = system.classicSystem.scheduler

--- a/core/src/main/scala/org/apache/pekko/projection/internal/InternalProjectionState.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/InternalProjectionState.scala
@@ -59,7 +59,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
     settings: ProjectionSettings) {
 
   def logger: LoggingAdapter
-  implicit def system: ActorSystem[_]
+  implicit def system: ActorSystem[?]
   implicit def executionContext: ExecutionContext
 
   private var telemetry: Telemetry = NoopTelemetry
@@ -273,10 +273,10 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
       }
 
       sourceProvider match {
-        case _: MergeableOffsetSourceProvider[_, _] =>
+        case _: MergeableOffsetSourceProvider[?, ?] =>
           val batches = envelopesAndOffsets
             .flatMap {
-              case context @ ProjectionContextImpl(offset: MergeableOffset[_] @unchecked, _, _, _) =>
+              case context @ ProjectionContextImpl(offset: MergeableOffset[?] @unchecked, _, _, _) =>
                 offset.entries.toSeq.map {
                   case (key, _) => (key, context)
                 }
@@ -360,7 +360,7 @@ private[projection] abstract class InternalProjectionState[Offset, Envelope](
               }
           }
 
-      case _: FlowHandlerStrategy[_] =>
+      case _: FlowHandlerStrategy[?] =>
         // not possible, no API for this
         throw new IllegalStateException("Unsupported combination of exactlyOnce and flow")
     }

--- a/core/src/main/scala/org/apache/pekko/projection/internal/OffsetSerialization.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/OffsetSerialization.scala
@@ -46,7 +46,7 @@ import pekko.serialization.Serializers
 /**
  * INTERNAL API
  */
-@InternalApi private[projection] class OffsetSerialization(system: ActorSystem[_]) {
+@InternalApi private[projection] class OffsetSerialization(system: ActorSystem[?]) {
   import OffsetSerialization._
 
   private val serialization = SerializationExtension(system)
@@ -101,7 +101,7 @@ import pekko.serialization.Serializers
       case i: Int                   => SingleOffset(id, IntManifest, i.toString, mergeable)
       case seq: query.Sequence      => SingleOffset(id, SequenceManifest, seq.value.toString, mergeable)
       case tbu: query.TimeBasedUUID => SingleOffset(id, TimeBasedUUIDManifest, tbu.value.toString, mergeable)
-      case mrg: MergeableOffset[_]  =>
+      case mrg: MergeableOffset[?]  =>
         val list = mrg.entries.map {
           case (key, innerOffset) =>
             toStorageRepresentation(ProjectionId(id.name, key), innerOffset, mergeable = true)

--- a/core/src/main/scala/org/apache/pekko/projection/internal/OffsetStrategy.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/OffsetStrategy.scala
@@ -138,7 +138,7 @@ private[projection] final case class GroupedHandlerStrategy[Envelope](
  */
 @InternalApi
 private[projection] final case class FlowHandlerStrategy[Envelope](
-    flowCtx: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _])
+    flowCtx: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?])
     extends HandlerStrategy {
 
   override def recreateHandlerOnNextAccess(): Unit = ()

--- a/core/src/main/scala/org/apache/pekko/projection/internal/ProjectionSerializer.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/ProjectionSerializer.scala
@@ -51,9 +51,9 @@ import pekko.serialization.SerializerWithStringManifest
   private val SetPausedManifest = "e"
 
   override def manifest(o: AnyRef): String = o match {
-    case _: GetOffset[_]     => GetOffsetManifest
-    case _: CurrentOffset[_] => CurrentOffsetManifest
-    case _: SetOffset[_]     => SetOffsetManifest
+    case _: GetOffset[?]     => GetOffsetManifest
+    case _: CurrentOffset[?] => CurrentOffsetManifest
+    case _: SetOffset[?]     => SetOffsetManifest
     case _: IsPaused         => IsPausedManifest
     case _: SetPaused        => SetPausedManifest
     case _                   =>
@@ -61,23 +61,23 @@ import pekko.serialization.SerializerWithStringManifest
   }
 
   override def toBinary(o: AnyRef): Array[Byte] = o match {
-    case m: GetOffset[_]     => getOffsetToBinary(m)
-    case m: CurrentOffset[_] => currentOffsetToBinary(m)
-    case m: SetOffset[_]     => setOffsetToBinary(m)
+    case m: GetOffset[?]     => getOffsetToBinary(m)
+    case m: CurrentOffset[?] => currentOffsetToBinary(m)
+    case m: SetOffset[?]     => setOffsetToBinary(m)
     case m: IsPaused         => isPausedToBinary(m)
     case m: SetPaused        => setPausedToBinary(m)
     case _                   =>
       throw new IllegalArgumentException(s"Cannot serialize object of type [${o.getClass.getName}]")
   }
 
-  private def getOffsetToBinary(m: GetOffset[_]): Array[Byte] = {
+  private def getOffsetToBinary(m: GetOffset[?]): Array[Byte] = {
     val b = ProjectionMessages.GetOffset.newBuilder()
     b.setProjectionId(projectionIdToProto(m.projectionId))
     b.setReplyTo(resolver.toSerializationFormat(m.replyTo))
     b.build().toByteArray()
   }
 
-  private def currentOffsetToBinary(m: CurrentOffset[_]): Array[Byte] = {
+  private def currentOffsetToBinary(m: CurrentOffset[?]): Array[Byte] = {
     val b = ProjectionMessages.CurrentOffset.newBuilder()
     b.setProjectionId(projectionIdToProto(m.projectionId))
     m.offset.foreach { o =>
@@ -86,7 +86,7 @@ import pekko.serialization.SerializerWithStringManifest
     b.build().toByteArray()
   }
 
-  private def setOffsetToBinary(m: SetOffset[_]): Array[Byte] = {
+  private def setOffsetToBinary(m: SetOffset[?]): Array[Byte] = {
     val b = ProjectionMessages.SetOffset.newBuilder()
     b.setProjectionId(projectionIdToProto(m.projectionId))
     b.setReplyTo(resolver.toSerializationFormat(m.replyTo))

--- a/core/src/main/scala/org/apache/pekko/projection/internal/ProjectionSettings.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/ProjectionSettings.scala
@@ -43,7 +43,7 @@ private[projection] final case class ProjectionSettings(
 @InternalApi
 private[projection] object ProjectionSettings {
 
-  def apply(system: ActorSystem[_]): ProjectionSettings = {
+  def apply(system: ActorSystem[?]): ProjectionSettings = {
     fromConfig(system.settings.config.getConfig("pekko.projection"))
   }
 
@@ -94,7 +94,7 @@ private object RecoveryStrategyConfig {
 /**
  * INTERNAL API: mixin to projection impl to not have to implement all overloaded variants in several places
  */
-@InternalApi private[projection] trait SettingsImpl[ProjectionImpl <: Projection[_]] { self: ProjectionImpl =>
+@InternalApi private[projection] trait SettingsImpl[ProjectionImpl <: Projection[?]] { self: ProjectionImpl =>
   def withRestartBackoffSettings(restartBackoff: RestartSettings): ProjectionImpl
 
   def withRestartBackoff(minBackoff: FiniteDuration, maxBackoff: FiniteDuration, randomFactor: Double): ProjectionImpl =

--- a/core/src/main/scala/org/apache/pekko/projection/internal/Telemetry.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/Telemetry.scala
@@ -98,7 +98,7 @@ trait Telemetry {
  * INTERNAL API
  */
 @InternalApi private[projection] object TelemetryProvider {
-  def start(projectionId: ProjectionId, system: ActorSystem[_]): Telemetry = {
+  def start(projectionId: ProjectionId, system: ActorSystem[?]): Telemetry = {
     if (!system.settings.config.hasPath("pekko.projection.telemetry.implementations")) {
       NoopTelemetry
     } else {
@@ -117,12 +117,12 @@ trait Telemetry {
     }
   }
 
-  def create(projectionId: ProjectionId, system: ActorSystem[_], fqcn: String) = {
+  def create(projectionId: ProjectionId, system: ActorSystem[?], fqcn: String) = {
     val dynamicAccess = system.dynamicAccess
     dynamicAccess
       .createInstanceFor[Telemetry](
         fqcn,
-        immutable.Seq((classOf[ProjectionId], projectionId), (classOf[ActorSystem[_]], system)))
+        immutable.Seq((classOf[ProjectionId], projectionId), (classOf[ActorSystem[?]], system)))
       .get
   }
 }
@@ -151,7 +151,7 @@ trait Telemetry {
 @InternalApi private[projection] class EnsembleTelemetry(
     telemetryFqcns: Seq[String],
     projectionId: ProjectionId,
-    system: ActorSystem[_])
+    system: ActorSystem[?])
     extends Telemetry {
 
   val telemetries = telemetryFqcns.map(fqcn => TelemetryProvider.create(projectionId, system, fqcn))

--- a/core/src/main/scala/org/apache/pekko/projection/javadsl/ProjectionManagement.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/javadsl/ProjectionManagement.scala
@@ -28,10 +28,10 @@ import pekko.projection.ProjectionId
 import pekko.projection.scaladsl
 
 @ApiMayChange object ProjectionManagement {
-  def get(system: ActorSystem[_]): ProjectionManagement = new ProjectionManagement(system)
+  def get(system: ActorSystem[?]): ProjectionManagement = new ProjectionManagement(system)
 }
 
-@ApiMayChange class ProjectionManagement(system: ActorSystem[_]) {
+@ApiMayChange class ProjectionManagement(system: ActorSystem[?]) {
   private val delegate = scaladsl.ProjectionManagement(system)
   private implicit val ec: ExecutionContext = system.executionContext
 

--- a/core/src/main/scala/org/apache/pekko/projection/javadsl/SourceProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/javadsl/SourceProvider.scala
@@ -48,4 +48,4 @@ trait VerifiableSourceProvider[Offset, Envelope] extends SourceProvider[Offset, 
 }
 
 @ApiMayChange
-trait MergeableOffsetSourceProvider[Offset <: MergeableOffset[_], Envelope] extends SourceProvider[Offset, Envelope]
+trait MergeableOffsetSourceProvider[Offset <: MergeableOffset[?], Envelope] extends SourceProvider[Offset, Envelope]

--- a/core/src/main/scala/org/apache/pekko/projection/scaladsl/ProjectionManagement.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/scaladsl/ProjectionManagement.scala
@@ -35,13 +35,13 @@ import pekko.projection.ProjectionId
 import pekko.util.Timeout
 
 @ApiMayChange object ProjectionManagement extends ExtensionId[ProjectionManagement] {
-  def createExtension(system: ActorSystem[_]): ProjectionManagement = new ProjectionManagement(system)
+  def createExtension(system: ActorSystem[?]): ProjectionManagement = new ProjectionManagement(system)
 
-  def get(system: ActorSystem[_]): ProjectionManagement = apply(system)
+  def get(system: ActorSystem[?]): ProjectionManagement = apply(system)
 }
 
-@ApiMayChange class ProjectionManagement(system: ActorSystem[_]) extends Extension {
-  private implicit val sys: ActorSystem[_] = system
+@ApiMayChange class ProjectionManagement(system: ActorSystem[?]) extends Extension {
+  private implicit val sys: ActorSystem[?] = system
   private implicit val askTimeout: Timeout = {
     system.settings.config.getDuration("pekko.projection.management.ask-timeout").toScala
   }

--- a/core/src/main/scala/org/apache/pekko/projection/scaladsl/SourceProvider.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/scaladsl/SourceProvider.scala
@@ -46,4 +46,4 @@ trait VerifiableSourceProvider[Offset, Envelope] extends SourceProvider[Offset, 
 }
 
 @ApiMayChange
-trait MergeableOffsetSourceProvider[Offset <: MergeableOffset[_], Envelope] extends SourceProvider[Offset, Envelope]
+trait MergeableOffsetSourceProvider[Offset <: MergeableOffset[?], Envelope] extends SourceProvider[Offset, Envelope]

--- a/durable-state/src/main/scala/org/apache/pekko/projection/state/javadsl/DurableStateSourceProvider.scala
+++ b/durable-state/src/main/scala/org/apache/pekko/projection/state/javadsl/DurableStateSourceProvider.scala
@@ -48,7 +48,7 @@ import pekko.stream.javadsl.Source
 @ApiMayChange
 object DurableStateSourceProvider {
   def changesByTag[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       pluginId: String,
       tag: String): SourceProvider[Offset, DurableStateChange[A]] = {
     val durableStateStoreQuery =
@@ -58,7 +58,7 @@ object DurableStateSourceProvider {
   }
 
   def changesByTag[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQuery: DurableStateStoreQuery[A],
       tag: String): SourceProvider[Offset, DurableStateChange[A]] = {
     new DurableStateStoreQuerySourceProvider(durableStateStoreQuery, tag, system)
@@ -68,7 +68,7 @@ object DurableStateSourceProvider {
   private class DurableStateStoreQuerySourceProvider[A](
       durableStateStoreQuery: DurableStateStoreQuery[A],
       tag: String,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends javadsl.SourceProvider[Offset, DurableStateChange[A]] {
     implicit val executionContext: ExecutionContext = system.executionContext
 
@@ -85,13 +85,13 @@ object DurableStateSourceProvider {
 
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
-        case u: UpdatedDurableState[_] => u.timestamp
-        case d: DeletedDurableState[_] => d.timestamp
+        case u: UpdatedDurableState[?] => u.timestamp
+        case d: DeletedDurableState[?] => d.timestamp
       }
   }
 
   def changesBySlices[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQueryPluginId: String,
       entityType: String,
       minSlice: Int,
@@ -103,7 +103,7 @@ object DurableStateSourceProvider {
   }
 
   def changesBySlices[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQuery: DurableStateStoreBySliceQuery[A],
       entityType: String,
       minSlice: Int,
@@ -112,7 +112,7 @@ object DurableStateSourceProvider {
   }
 
   def sliceForPersistenceId(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQueryPluginId: String,
       persistenceId: String): Int =
     DurableStateStoreRegistry(system)
@@ -120,7 +120,7 @@ object DurableStateSourceProvider {
       .sliceForPersistenceId(persistenceId)
 
   def sliceRanges(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQueryPluginId: String,
       numberOfRanges: Int): java.util.List[Pair[Integer, Integer]] =
     DurableStateStoreRegistry(system)
@@ -132,7 +132,7 @@ object DurableStateSourceProvider {
       entityType: String,
       override val minSlice: Int,
       override val maxSlice: Int,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends SourceProvider[Offset, DurableStateChange[A]]
       with BySlicesSourceProvider
       with DurableStateStore[A] {
@@ -151,8 +151,8 @@ object DurableStateSourceProvider {
 
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
-        case u: UpdatedDurableState[_] => u.timestamp
-        case d: DeletedDurableState[_] => d.timestamp
+        case u: UpdatedDurableState[?] => u.timestamp
+        case d: DeletedDurableState[?] => d.timestamp
       }
 
     override def getObject(persistenceId: String): CompletionStage[GetObjectResult[A]] =

--- a/durable-state/src/main/scala/org/apache/pekko/projection/state/scaladsl/DurableStateSourceProvider.scala
+++ b/durable-state/src/main/scala/org/apache/pekko/projection/state/scaladsl/DurableStateSourceProvider.scala
@@ -42,7 +42,7 @@ import pekko.stream.scaladsl.Source
 object DurableStateSourceProvider {
 
   def changesByTag[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       pluginId: String,
       tag: String): SourceProvider[Offset, DurableStateChange[A]] = {
     val durableStateStoreQuery =
@@ -51,7 +51,7 @@ object DurableStateSourceProvider {
   }
 
   def changesByTag[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQuery: DurableStateStoreQuery[A],
       tag: String): SourceProvider[Offset, DurableStateChange[A]] = {
     new DurableStateStoreQuerySourceProvider(durableStateStoreQuery, tag, system)
@@ -60,7 +60,7 @@ object DurableStateSourceProvider {
   private class DurableStateStoreQuerySourceProvider[A](
       durableStateStoreQuery: DurableStateStoreQuery[A],
       tag: String,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends SourceProvider[Offset, DurableStateChange[A]] {
     implicit val executionContext: ExecutionContext = system.executionContext
 
@@ -75,13 +75,13 @@ object DurableStateSourceProvider {
 
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
-        case u: UpdatedDurableState[_] => u.timestamp
-        case d: DeletedDurableState[_] => d.timestamp
+        case u: UpdatedDurableState[?] => u.timestamp
+        case d: DeletedDurableState[?] => d.timestamp
       }
   }
 
   def changesBySlices[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQueryPluginId: String,
       entityType: String,
       minSlice: Int,
@@ -93,7 +93,7 @@ object DurableStateSourceProvider {
   }
 
   def changesBySlices[A](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQuery: DurableStateStoreBySliceQuery[A],
       entityType: String,
       minSlice: Int,
@@ -102,7 +102,7 @@ object DurableStateSourceProvider {
   }
 
   def sliceForPersistenceId(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQueryPluginId: String,
       persistenceId: String): Int =
     DurableStateStoreRegistry(system)
@@ -110,7 +110,7 @@ object DurableStateSourceProvider {
       .sliceForPersistenceId(persistenceId)
 
   def sliceRanges(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       durableStateStoreQueryPluginId: String,
       numberOfRanges: Int): immutable.Seq[Range] =
     DurableStateStoreRegistry(system)
@@ -122,7 +122,7 @@ object DurableStateSourceProvider {
       entityType: String,
       override val minSlice: Int,
       override val maxSlice: Int,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends SourceProvider[Offset, DurableStateChange[A]]
       with BySlicesSourceProvider
       with DurableStateStore[A] {
@@ -139,8 +139,8 @@ object DurableStateSourceProvider {
 
     override def extractCreationTime(stateChange: DurableStateChange[A]): Long =
       stateChange match {
-        case u: UpdatedDurableState[_] => u.timestamp
-        case d: DeletedDurableState[_] => d.timestamp
+        case u: UpdatedDurableState[?] => u.timestamp
+        case d: DeletedDurableState[?] => d.timestamp
       }
 
     override def getObject(persistenceId: String): Future[GetObjectResult[A]] =

--- a/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/EventEnvelope.scala
+++ b/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/EventEnvelope.scala
@@ -74,7 +74,7 @@ final class EventEnvelope[Event](
 
   override def equals(other: Any): Boolean =
     other match {
-      case that: EventEnvelope[_] =>
+      case that: EventEnvelope[?] =>
         offset == that.offset &&
         persistenceId == that.persistenceId &&
         sequenceNr == that.sequenceNr &&

--- a/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/javadsl/EventSourcedProvider.scala
+++ b/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/javadsl/EventSourcedProvider.scala
@@ -48,7 +48,7 @@ import pekko.stream.javadsl.Source
 object EventSourcedProvider {
 
   def eventsByTag[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
     val eventsByTagQuery =
@@ -57,7 +57,7 @@ object EventSourcedProvider {
   }
 
   def eventsByTag[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
@@ -67,7 +67,7 @@ object EventSourcedProvider {
   }
 
   def eventsByTag[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       eventsByTagQuery: EventsByTagQuery,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
     new EventsByTagSourceProvider(system, eventsByTagQuery, tag)
@@ -78,7 +78,7 @@ object EventSourcedProvider {
    */
   @InternalApi
   private class EventsByTagSourceProvider[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       eventsByTagQuery: EventsByTagQuery,
       tag: String)
       extends javadsl.SourceProvider[Offset, EventEnvelope[Event]] {
@@ -100,7 +100,7 @@ object EventSourcedProvider {
   }
 
   def eventsBySlices[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       entityType: String,
       minSlice: Int,
@@ -111,7 +111,7 @@ object EventSourcedProvider {
   }
 
   def eventsBySlices[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       entityType: String,
@@ -123,7 +123,7 @@ object EventSourcedProvider {
   }
 
   def eventsBySlices[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       eventsBySlicesQuery: EventsBySliceQuery,
       entityType: String,
       minSlice: Int,
@@ -140,14 +140,14 @@ object EventSourcedProvider {
     }
   }
 
-  def sliceForPersistenceId(system: ActorSystem[_], readJournalPluginId: String, persistenceId: String): Int =
+  def sliceForPersistenceId(system: ActorSystem[?], readJournalPluginId: String, persistenceId: String): Int =
     PersistenceQuery(system)
       .getReadJournalFor(classOf[EventsBySliceQuery], readJournalPluginId)
       .sliceForPersistenceId(persistenceId)
 
   /** @since 2.0.0 */
   def sliceForPersistenceId(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       persistenceId: String
@@ -157,7 +157,7 @@ object EventSourcedProvider {
       .sliceForPersistenceId(persistenceId)
 
   def sliceRanges(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       numberOfRanges: Int): java.util.List[Pair[Integer, Integer]] =
     PersistenceQuery(system)
@@ -166,7 +166,7 @@ object EventSourcedProvider {
 
   /** @since 2.0.0 */
   def sliceRanges(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       numberOfRanges: Int): java.util.List[Pair[Integer, Integer]] =
@@ -183,7 +183,7 @@ object EventSourcedProvider {
       entityType: String,
       override val minSlice: Int,
       override val maxSlice: Int,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]]
       with BySlicesSourceProvider
       with EventTimestampQuery

--- a/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/scaladsl/EventSourcedProvider.scala
+++ b/eventsourced/src/main/scala/org/apache/pekko/projection/eventsourced/scaladsl/EventSourcedProvider.scala
@@ -40,7 +40,7 @@ import pekko.stream.scaladsl.Source
 object EventSourcedProvider {
 
   def eventsByTag[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
     val eventsByTagQuery =
@@ -49,7 +49,7 @@ object EventSourcedProvider {
   }
 
   def eventsByTag[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
@@ -59,7 +59,7 @@ object EventSourcedProvider {
   }
 
   def eventsByTag[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       eventsByTagQuery: EventsByTagQuery,
       tag: String): SourceProvider[Offset, EventEnvelope[Event]] = {
     new EventsByTagSourceProvider(eventsByTagQuery, tag, system)
@@ -68,7 +68,7 @@ object EventSourcedProvider {
   private class EventsByTagSourceProvider[Event](
       eventsByTagQuery: EventsByTagQuery,
       tag: String,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends SourceProvider[Offset, EventEnvelope[Event]] {
     implicit val executionContext: ExecutionContext = system.executionContext
 
@@ -86,7 +86,7 @@ object EventSourcedProvider {
   }
 
   def eventsBySlices[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       entityType: String,
       minSlice: Int,
@@ -97,7 +97,7 @@ object EventSourcedProvider {
   }
 
   def eventsBySlices[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       entityType: String,
@@ -109,7 +109,7 @@ object EventSourcedProvider {
   }
 
   def eventsBySlices[Event](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       eventsBySlicesQuery: EventsBySliceQuery,
       entityType: String,
       minSlice: Int,
@@ -126,14 +126,14 @@ object EventSourcedProvider {
     }
   }
 
-  def sliceForPersistenceId(system: ActorSystem[_], readJournalPluginId: String, persistenceId: String): Int =
+  def sliceForPersistenceId(system: ActorSystem[?], readJournalPluginId: String, persistenceId: String): Int =
     PersistenceQuery(system)
       .readJournalFor[EventsBySliceQuery](readJournalPluginId)
       .sliceForPersistenceId(persistenceId)
 
   /** @since 2.0.0 */
   def sliceForPersistenceId(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       persistenceId: String): Int =
@@ -141,12 +141,12 @@ object EventSourcedProvider {
       .readJournalFor[EventsBySliceQuery](readJournalPluginId, readJournalConfig)
       .sliceForPersistenceId(persistenceId)
 
-  def sliceRanges(system: ActorSystem[_], readJournalPluginId: String, numberOfRanges: Int): immutable.Seq[Range] =
+  def sliceRanges(system: ActorSystem[?], readJournalPluginId: String, numberOfRanges: Int): immutable.Seq[Range] =
     PersistenceQuery(system).readJournalFor[EventsBySliceQuery](readJournalPluginId).sliceRanges(numberOfRanges)
 
   /** @since 2.0.0 */
   def sliceRanges(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       readJournalPluginId: String,
       readJournalConfig: Config,
       numberOfRanges: Int): immutable.Seq[Range] =
@@ -159,7 +159,7 @@ object EventSourcedProvider {
       entityType: String,
       override val minSlice: Int,
       override val maxSlice: Int,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends SourceProvider[Offset, pekko.persistence.query.typed.EventEnvelope[Event]]
       with BySlicesSourceProvider
       with EventTimestampQuery

--- a/examples/src/test/scala/docs/classic/ClassicDocExample.scala
+++ b/examples/src/test/scala/docs/classic/ClassicDocExample.scala
@@ -25,7 +25,7 @@ object ClassicDocExample {
     import pekko.actor.typed.scaladsl.adapter._
 
     private val system = pekko.actor.ActorSystem("Example")
-    private val typedSystem: pekko.actor.typed.ActorSystem[_] = system.toTyped
+    private val typedSystem: pekko.actor.typed.ActorSystem[?] = system.toTyped
     // #system
 
     typedSystem.terminate() // avoid unused warning

--- a/examples/src/test/scala/docs/eventsourced/ShoppingCart.scala
+++ b/examples/src/test/scala/docs/eventsourced/ShoppingCart.scala
@@ -152,7 +152,7 @@ object ShoppingCart {
   // #tagging
   val EntityKey: EntityTypeKey[Command] = EntityTypeKey[Command]("ShoppingCart")
 
-  def init(system: ActorSystem[_]): Unit = {
+  def init(system: ActorSystem[?]): Unit = {
     ClusterSharding(system).init(Entity(EntityKey) { entityContext =>
       val i = math.abs(entityContext.entityId.hashCode % tags.size)
       val selectedTag = tags(i)

--- a/examples/src/test/scala/docs/guide/ItemPopularityProjectionHandler.scala
+++ b/examples/src/test/scala/docs/guide/ItemPopularityProjectionHandler.scala
@@ -30,7 +30,7 @@ object ItemPopularityProjectionHandler {
   val LogInterval = 10
 }
 
-class ItemPopularityProjectionHandler(tag: String, system: ActorSystem[_], repo: ItemPopularityProjectionRepository)
+class ItemPopularityProjectionHandler(tag: String, system: ActorSystem[?], repo: ItemPopularityProjectionRepository)
     extends Handler[EventEnvelope[ShoppingCartEvents.Event]]() {
   import ShoppingCartEvents._
 

--- a/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/IntegrationSpec.scala
+++ b/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/IntegrationSpec.scala
@@ -117,7 +117,7 @@ class IntegrationSpec(testContainerConf: TestContainerConf)
 
   def this() = this(new TestContainerConf)
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private implicit val ec: ExecutionContext = system.executionContext
   private val numberOfTests = 6
 

--- a/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/TestDbLifecycle.scala
+++ b/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/TestDbLifecycle.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration._
 
 trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
 
-  def typedSystem: ActorSystem[_]
+  def typedSystem: ActorSystem[?]
 
   def testConfigPath: String = "pekko.projection.r2dbc"
 

--- a/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/EventTimestampQuerySpec.scala
+++ b/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/EventTimestampQuerySpec.scala
@@ -56,7 +56,7 @@ class EventTimestampQuerySpec(testContainerConf: TestContainerConf)
     testContainerConf.stop()
   }
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private implicit val ec: ExecutionContext = system.executionContext
   private val entityType = nextEntityType()
   private val streamId = "stream_id_" + entityType

--- a/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/LoadEventQuerySpec.scala
+++ b/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/LoadEventQuerySpec.scala
@@ -52,7 +52,7 @@ class LoadEventQuerySpec(testContainerConf: TestContainerConf)
 
   def this() = this(new TestContainerConf)
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private implicit val ec: ExecutionContext = system.executionContext
   private val entityType = nextEntityType()
   private val streamId = "stream_id_" + entityType

--- a/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/producer/ProducerFilterEndToEndSpec.scala
+++ b/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/producer/ProducerFilterEndToEndSpec.scala
@@ -104,7 +104,7 @@ class ProducerFilterEndToEndSpec(testContainerConf: TestContainerConf)
 
   import ProducerFilterEndToEndSpec._
 
-  override def typedSystem: ActorSystem[_] = testKit.system
+  override def typedSystem: ActorSystem[?] = testKit.system
   private implicit val ec: ExecutionContext = typedSystem.executionContext
 
   private val grpcPort: Int = SocketUtil.temporaryServerAddress("127.0.0.1").getPort

--- a/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/replication/ReplicationIntegrationSpec.scala
+++ b/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/replication/ReplicationIntegrationSpec.scala
@@ -155,9 +155,9 @@ class ReplicationIntegrationSpec(testContainerConf: TestContainerConf)
   def this() = this(new TestContainerConf)
 
   private val logger = LoggerFactory.getLogger(classOf[ReplicationIntegrationSpec])
-  override def typedSystem: ActorSystem[_] = testKit.system
+  override def typedSystem: ActorSystem[?] = testKit.system
 
-  private val systems = Seq[ActorSystem[_]](
+  private val systems = Seq[ActorSystem[?]](
     typedSystem,
     pekko.actor.ActorSystem(
       "ReplicationIntegrationSpecB",
@@ -196,7 +196,7 @@ class ReplicationIntegrationSpec(testContainerConf: TestContainerConf)
     }
   }
 
-  def startReplica(replicaSystem: ActorSystem[_], selfReplicaId: ReplicaId): Replication[LWWHelloWorld.Command] = {
+  def startReplica(replicaSystem: ActorSystem[?], selfReplicaId: ReplicaId): Replication[LWWHelloWorld.Command] = {
     val settings = ReplicationSettings[LWWHelloWorld.Command](
       "hello-world",
       selfReplicaId,

--- a/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/replication/ReplicationJavaDSLIntegrationSpec.scala
+++ b/grpc-int-test/src/test/scala/org/apache/pekko/projection/grpc/replication/ReplicationJavaDSLIntegrationSpec.scala
@@ -176,9 +176,9 @@ class ReplicationJavaDSLIntegrationSpec(testContainerConf: TestContainerConf)
   def this() = this(new TestContainerConf)
 
   private val logger = LoggerFactory.getLogger(classOf[ReplicationIntegrationSpec])
-  override def typedSystem: ActorSystem[_] = testKit.system
+  override def typedSystem: ActorSystem[?] = testKit.system
 
-  private val systems = Seq[ActorSystem[_]](
+  private val systems = Seq[ActorSystem[?]](
     typedSystem,
     pekko.actor.ActorSystem(
       "ReplicationJavaDSLIntegrationSpecB",
@@ -217,7 +217,7 @@ class ReplicationJavaDSLIntegrationSpec(testContainerConf: TestContainerConf)
     }
   }
 
-  def startReplica(replicaSystem: ActorSystem[_], selfReplicaId: ReplicaId): Replication[LWWHelloWorld.Command] = {
+  def startReplica(replicaSystem: ActorSystem[?], selfReplicaId: ReplicaId): Replication[LWWHelloWorld.Command] = {
     val settings = ReplicationSettings.create(
       classOf[LWWHelloWorld.Command],
       "hello-world-java",

--- a/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/internal/EventProducerServiceSpec.scala
+++ b/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/internal/EventProducerServiceSpec.scala
@@ -61,7 +61,7 @@ import scala.concurrent.Promise
 object EventProducerServiceSpec {
   val grpcPort: Int = SocketUtil.temporaryServerAddress("127.0.0.1").getPort
 
-  class TestEventsBySliceQuery()(implicit system: ActorSystem[_]) extends ReadJournal with EventsBySliceQuery {
+  class TestEventsBySliceQuery()(implicit system: ActorSystem[?]) extends ReadJournal with EventsBySliceQuery {
     private val persistenceExt = Persistence(system)
 
     private val testPublisherPromise =

--- a/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/internal/FilterStageSpec.scala
+++ b/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/internal/FilterStageSpec.scala
@@ -126,7 +126,7 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
       }
 
     private val envPublisherPromise = Promise[TestPublisher.Probe[EventEnvelope[Any]]]()
-    private val envSource: Source[EventEnvelope[Any], _] =
+    private val envSource: Source[EventEnvelope[Any], ?] =
       TestSource()
         .mapMaterializedValue(envPublisherPromise.success)
     private val envFlow: Flow[StreamIn, EventEnvelope[Any], NotUsed] =

--- a/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ProducerApiSample.scala
+++ b/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ProducerApiSample.scala
@@ -30,7 +30,7 @@ object ProducerApiSample {
 
   def otherReplication: Replication[Unit] = ???
   def multiEventProducers(settings: ReplicationSettings[MyCommand], host: String, port: Int)(
-      implicit system: ActorSystem[_]): Unit = {
+      implicit system: ActorSystem[?]): Unit = {
     // #multi-service
     val replication: Replication[MyCommand] =
       Replication.grpcReplication(settings)(MyReplicatedBehavior.apply)

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/consumer/ConsumerFilter.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/consumer/ConsumerFilter.scala
@@ -284,12 +284,12 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
 
   final case class PersistenceIdOffset(persistenceIdId: String, seqNr: Long)
 
-  override def createExtension(system: ActorSystem[_]): ConsumerFilter = new ConsumerFilter(system)
+  override def createExtension(system: ActorSystem[?]): ConsumerFilter = new ConsumerFilter(system)
 
   /**
    * Java API: retrieve the extension instance for the given system.
    */
-  def get(system: ActorSystem[_]): ConsumerFilter = apply(system)
+  def get(system: ActorSystem[?]): ConsumerFilter = apply(system)
 
   /**
    * INTERNAL API
@@ -514,7 +514,7 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
 
   /** INTERNAL API */
   @InternalApi private[pekko] object ConsumerFilterSettings {
-    def apply(system: ActorSystem[_]): ConsumerFilterSettings =
+    def apply(system: ActorSystem[?]): ConsumerFilterSettings =
       apply(system.settings.config.getConfig("pekko.projection.grpc.consumer.filter"))
 
     def apply(config: Config): ConsumerFilterSettings =
@@ -531,7 +531,7 @@ object ConsumerFilter extends ExtensionId[ConsumerFilter] {
 }
 
 @ApiMayChange
-class ConsumerFilter(system: ActorSystem[_]) extends Extension {
+class ConsumerFilter(system: ActorSystem[?]) extends Extension {
 
   private val settings = ConsumerFilter.ConsumerFilterSettings(system)
 

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -185,7 +185,7 @@ final class GrpcReadJournal private (
   def this(system: ExtendedActorSystem, config: Config, cfgPath: String) =
     this(system, config, cfgPath, ProtoAnySerialization.Prefer.Scala)
 
-  private implicit val typedSystem: pekko.actor.typed.ActorSystem[_] = system.toTyped
+  private implicit val typedSystem: pekko.actor.typed.ActorSystem[?] = system.toTyped
   private val persistenceExt = Persistence(system)
 
   lazy val consumerFilter = ConsumerFilter(typedSystem)

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ConsumerFilterStore.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ConsumerFilterStore.scala
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory
   final case class GetFilter(replyTo: ActorRef[ConsumerFilter.CurrentFilter]) extends Command
 
   def apply(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       settings: ConsumerFilterSettings,
       streamId: String,
       notifyUpdatesTo: ActorRef[ConsumerFilterRegistry.FilterUpdated]): Behavior[Command] = {
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory
     }
   }
 
-  def useDistributedData(system: ActorSystem[_]): Boolean = {
+  def useDistributedData(system: ActorSystem[?]): Boolean = {
     system.classicSystem
       .asInstanceOf[ExtendedActorSystem]
       .provider
@@ -84,7 +84,7 @@ import org.slf4j.LoggerFactory
    * pekko-cluster-typed dependency is optional so we create the DdataConsumerFilterStore with reflection
    */
   def createDdataConsumerFilterStore(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       settings: ConsumerFilterSettings,
       streamId: String,
       notifyUpdatesTo: ActorRef[ConsumerFilterRegistry.FilterUpdated]): Behavior[Command] = {
@@ -113,7 +113,7 @@ import org.slf4j.LoggerFactory
  */
 @InternalApi private[pekko] object LocalConsumerFilterStore {
   private object StoreExt extends ExtensionId[StoreExt] {
-    override def createExtension(system: ActorSystem[_]): StoreExt = new StoreExt
+    override def createExtension(system: ActorSystem[?]): StoreExt = new StoreExt
   }
 
   private class StoreExt extends Extension {

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ConsumerSerializer.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ConsumerSerializer.scala
@@ -70,7 +70,7 @@ import scalapb.GeneratedMessage
         s"Unimplemented deserialization of message with manifest [$manifest] in [${getClass.getName}]")
   }
 
-  private def orsetToBytes(orset: ORSet[_]): ByteString = {
+  private def orsetToBytes(orset: ORSet[?]): ByteString = {
     toProtoByteStringUnsafe(replicatedDataSerializer.orsetToProto(orset).toByteArray)
   }
 

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/EventProducerServiceImpl.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/EventProducerServiceImpl.scala
@@ -70,7 +70,7 @@ import scala.util.Success
  * INTERNAL API
  */
 @InternalApi private[pekko] class EventProducerServiceImpl(
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     eventsBySlicesQueriesPerStreamId: Map[String, EventsBySliceQuery],
     currentEventsByPersistenceIdQueriesPerStreamId: Map[String, CurrentEventsByPersistenceIdTypedQuery],
     sources: Set[EventProducer.EventProducerSource],
@@ -204,7 +204,7 @@ import scala.util.Success
     Flow.futureFlow(futureFlow).mapMaterializedValue(_ => NotUsed)
   }
 
-  private def protoOffset(env: EventEnvelope[_]): Offset = {
+  private def protoOffset(env: EventEnvelope[?]): Offset = {
     env.offset match {
       case TimestampOffset(timestamp, _, seen) =>
         val protoTimestamp = Timestamp(timestamp)
@@ -218,7 +218,7 @@ import scala.util.Success
     }
   }
 
-  private def transformAndEncodeEvent(transformation: Transformation, env: EventEnvelope[_]): Future[Option[Event]] = {
+  private def transformAndEncodeEvent(transformation: Transformation, env: EventEnvelope[?]): Future[Option[Event]] = {
     env.eventOption match {
       case Some(_) =>
         import system.executionContext

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/FilterStage.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/FilterStage.scala
@@ -105,7 +105,7 @@ import org.slf4j.LoggerFactory
      * If an exclude criteria is matching the include criteria are evaluated.
      * Returns `true` if there is a matching include criteria, otherwise `false`.
      */
-    def matches(env: EventEnvelope[_]): Boolean = {
+    def matches(env: EventEnvelope[?]): Boolean = {
       val pid = env.persistenceId
 
       def matchesRegexEntityIds(regexValues: Iterable[Regex]): Boolean = {

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/ProtoAnySerialization.scala
@@ -65,7 +65,7 @@ import scalapb.options.Scalapb
   }
 
   private final class ScalaPbResolvedType[T <: scalapb.GeneratedMessage](
-      companion: scalapb.GeneratedMessageCompanion[_])
+      companion: scalapb.GeneratedMessageCompanion[?])
       extends ResolvedType[T] {
     override def parseFrom(bytes: ByteString): T = companion.parseFrom(bytes.newCodedInput()).asInstanceOf[T]
   }
@@ -105,7 +105,7 @@ import scalapb.options.Scalapb
  * INTERNAL API
  */
 @InternalApi private[pekko] class ProtoAnySerialization(
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     descriptors: immutable.Seq[Descriptors.FileDescriptor],
     prefer: ProtoAnySerialization.Prefer) {
   import ProtoAnySerialization._
@@ -124,7 +124,7 @@ import scalapb.options.Scalapb
   /**
    * If only used for encoding messages and not decoding messages.
    */
-  def this(system: ActorSystem[_]) =
+  def this(system: ActorSystem[?]) =
     this(system, descriptors = Nil, ProtoAnySerialization.Prefer.Scala)
 
   def serialize(event: Any): ScalaPbAny = {
@@ -241,7 +241,7 @@ import scalapb.options.Scalapb
       case iae @ (_: IllegalAccessException | _: IllegalArgumentException) =>
         throw SerializationException(s"Could not invoke $className.parser()", iae)
       case cce: ClassCastException =>
-        throw SerializationException(s"$className.parser() did not return a ${classOf[Parser[_]]}", cce)
+        throw SerializationException(s"$className.parser() did not return a ${classOf[Parser[?]]}", cce)
     }
   }
 
@@ -311,7 +311,7 @@ import scalapb.options.Scalapb
         })
       .get
 
-  private def resolveTypeUrl(typeName: String): Option[ResolvedType[_]] =
+  private def resolveTypeUrl(typeName: String): Option[ResolvedType[?]] =
     allTypes.get(typeName).map(resolveTypeDescriptor)
 
   def encode(value: Any): ScalaPbAny =

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/producer/EventProducerSettings.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/producer/EventProducerSettings.scala
@@ -20,7 +20,7 @@ import com.typesafe.config.Config
 
 @ApiMayChange
 object EventProducerSettings {
-  def apply(system: ActorSystem[_]): EventProducerSettings =
+  def apply(system: ActorSystem[?]): EventProducerSettings =
     apply(system.settings.config.getConfig("pekko.projection.grpc.producer"))
 
   def apply(config: Config): EventProducerSettings = {

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/producer/javadsl/EventProducer.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/producer/javadsl/EventProducer.scala
@@ -43,7 +43,7 @@ object EventProducer {
    * @param source The source that should be available from this event producer
    */
   def grpcServiceHandler(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       source: EventProducerSource): JapiFunction[HttpRequest, CompletionStage[HttpResponse]] =
     grpcServiceHandler(system, Collections.singleton(source))
 
@@ -53,7 +53,7 @@ object EventProducer {
    * @param sources All sources that should be available from this event producer
    */
   def grpcServiceHandler(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       sources: java.util.Set[EventProducerSource]): JapiFunction[HttpRequest, CompletionStage[HttpResponse]] =
     grpcServiceHandler(system, sources, Optional.empty())
 
@@ -64,7 +64,7 @@ object EventProducer {
    * @param interceptor An optional request interceptor applied to each request to the service
    */
   def grpcServiceHandler(
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       sources: java.util.Set[EventProducerSource],
       interceptor: Optional[EventProducerInterceptor]): JapiFunction[HttpRequest, CompletionStage[HttpResponse]] = {
     val scalaProducerSources = sources.asScala.map(_.asScala).toSet

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/producer/scaladsl/EventProducer.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/producer/scaladsl/EventProducer.scala
@@ -109,7 +109,7 @@ object EventProducer {
    */
   @ApiMayChange
   final class Transformation private (
-      private[pekko] val mappers: Map[Class[_], EventEnvelope[Any] => Future[Option[Any]]],
+      private[pekko] val mappers: Map[Class[?], EventEnvelope[Any] => Future[Option[Any]]],
       private[pekko] val orElse: EventEnvelope[Any] => Future[Option[Any]]) {
 
     /**
@@ -156,7 +156,7 @@ object EventProducer {
    * The gRPC route that can be included in a Pekko HTTP server.
    */
   def grpcServiceHandler(source: EventProducerSource)(
-      implicit system: ActorSystem[_]): PartialFunction[HttpRequest, scala.concurrent.Future[HttpResponse]] =
+      implicit system: ActorSystem[?]): PartialFunction[HttpRequest, scala.concurrent.Future[HttpResponse]] =
     grpcServiceHandler(Set(source))
 
   /**
@@ -165,7 +165,7 @@ object EventProducer {
    * @param sources All sources that should be available from this event producer
    */
   def grpcServiceHandler(sources: Set[EventProducerSource])(
-      implicit system: ActorSystem[_]): PartialFunction[HttpRequest, scala.concurrent.Future[HttpResponse]] = {
+      implicit system: ActorSystem[?]): PartialFunction[HttpRequest, scala.concurrent.Future[HttpResponse]] = {
 
     grpcServiceHandler(sources, None)
   }
@@ -177,7 +177,7 @@ object EventProducer {
    * @param interceptor An optional request interceptor applied to each request to the service
    */
   def grpcServiceHandler(sources: Set[EventProducerSource], interceptor: Option[EventProducerInterceptor])(
-      implicit system: ActorSystem[_]): PartialFunction[HttpRequest, scala.concurrent.Future[HttpResponse]] = {
+      implicit system: ActorSystem[?]): PartialFunction[HttpRequest, scala.concurrent.Future[HttpResponse]] = {
 
     EventProducerServicePowerApiHandler.partial(
       new EventProducerServiceImpl(
@@ -193,7 +193,7 @@ object EventProducer {
    */
   private[pekko] def eventsBySlicesQueriesForStreamIds(
       sources: Set[EventProducerSource],
-      system: ActorSystem[_]): Map[String, EventsBySliceQuery] = {
+      system: ActorSystem[?]): Map[String, EventsBySliceQuery] = {
     queriesForStreamIds(sources, system).map {
       case (streamId, q: EventsBySliceQuery) => streamId -> q
       case (_, other)                        =>
@@ -206,7 +206,7 @@ object EventProducer {
    */
   private[pekko] def currentEventsByPersistenceIdQueriesForStreamIds(
       sources: Set[EventProducerSource],
-      system: ActorSystem[_]): Map[String, CurrentEventsByPersistenceIdTypedQuery] = {
+      system: ActorSystem[?]): Map[String, CurrentEventsByPersistenceIdTypedQuery] = {
     queriesForStreamIds(sources, system).map {
       case (streamId, q: CurrentEventsByPersistenceIdTypedQuery) => streamId -> q
       case (_, other)                                            =>
@@ -217,7 +217,7 @@ object EventProducer {
 
   private def queriesForStreamIds(
       sources: Set[EventProducerSource],
-      system: ActorSystem[_]): Map[String, ReadJournal] = {
+      system: ActorSystem[?]): Map[String, ReadJournal] = {
     val streamIds = sources.map(_.streamId)
     require(
       streamIds.size == sources.size,

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/internal/ReplicationImpl.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/internal/ReplicationImpl.scala
@@ -74,7 +74,7 @@ private[pekko] final class ReplicationImpl[Command] private (
 @InternalApi
 private[pekko] object ReplicationImpl {
 
-  private val log = LoggerFactory.getLogger(classOf[ReplicationImpl[_]])
+  private val log = LoggerFactory.getLogger(classOf[ReplicationImpl[?]])
 
   private val filteredEvent = Future.successful(None)
 
@@ -86,7 +86,7 @@ private[pekko] object ReplicationImpl {
   def grpcReplication[Command, Event, State](
       settings: ReplicationSettings[Command],
       producerFilter: EventEnvelope[Event] => Boolean,
-      replicatedEntity: ReplicatedEntity[Command])(implicit system: ActorSystem[_]): ReplicationImpl[Command] = {
+      replicatedEntity: ReplicatedEntity[Command])(implicit system: ActorSystem[?]): ReplicationImpl[Command] = {
     require(
       system.classicSystem.asInstanceOf[ExtendedActorSystem].provider.isInstanceOf[ClusterActorRefProvider],
       "Replicated Event Sourcing over gRPC only possible together with Pekko cluster (pekko.actor.provider = cluster)")
@@ -125,7 +125,7 @@ private[pekko] object ReplicationImpl {
   private def startConsumer[C](
       remoteReplica: Replica,
       settings: ReplicationSettings[C],
-      entityRefFactory: String => EntityRef[C])(implicit system: ActorSystem[_]): Unit = {
+      entityRefFactory: String => EntityRef[C])(implicit system: ActorSystem[?]): Unit = {
     implicit val timeout: Timeout = settings.entityEventReplicationTimeout
     implicit val ec: ExecutionContext = system.executionContext
 

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/internal/ReplicationProjectionProviderAdapter.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/internal/ReplicationProjectionProviderAdapter.scala
@@ -40,7 +40,7 @@ private[pekko] object ReplicationProjectionProviderAdapter {
         projectionId: ProjectionId,
         sourceProvider: SSourceProvider[Offset, EventEnvelope[AnyRef]],
         replicationFlow: SFlowWithContext[EventEnvelope[AnyRef], ProjectionContext, Done, ProjectionContext, NotUsed],
-        system: ActorSystem[_]) =>
+        system: ActorSystem[?]) =>
       val providerWithSlices = sourceProvider match {
         case withSlices: SSourceProvider[Offset, EventEnvelope[AnyRef]] with BySlicesSourceProvider => withSlices
         case noSlices                                                                               =>

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/Replication.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/Replication.scala
@@ -87,7 +87,7 @@ object Replication {
   def grpcReplication[Command, Event, State](
       settings: ReplicationSettings[Command],
       replicatedBehaviorFactory: JFunction[ReplicatedBehaviors[Command, Event, State], Behavior[Command]],
-      system: ActorSystem[_]): Replication[Command] = {
+      system: ActorSystem[?]): Replication[Command] = {
     val trueProducerFilter = new Predicate[EventEnvelope[Event]] {
       override def test(env: EventEnvelope[Event]): Boolean = true
     }
@@ -103,7 +103,7 @@ object Replication {
       settings: ReplicationSettings[Command],
       producerFilter: Predicate[EventEnvelope[Event]],
       replicatedBehaviorFactory: JFunction[ReplicatedBehaviors[Command, Event, State], Behavior[Command]],
-      system: ActorSystem[_]): Replication[Command] = {
+      system: ActorSystem[?]): Replication[Command] = {
 
     val scalaReplicationSettings = settings.toScala
 

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/ReplicationProjectionProvider.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/ReplicationProjectionProvider.scala
@@ -37,6 +37,6 @@ trait ReplicationProjectionProvider {
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, EventEnvelope[AnyRef]],
       replicationFlow: FlowWithContext[EventEnvelope[AnyRef], ProjectionContext, Done, ProjectionContext, NotUsed],
-      system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, EventEnvelope[AnyRef]]
+      system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, EventEnvelope[AnyRef]]
 
 }

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/ReplicationSettings.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/ReplicationSettings.scala
@@ -90,7 +90,7 @@ object ReplicationSettings {
       commandClass: Class[Command],
       entityTypeName: String,
       replicationProjectionProvider: ReplicationProjectionProvider,
-      system: ActorSystem[_]): ReplicationSettings[Command] = {
+      system: ActorSystem[?]): ReplicationSettings[Command] = {
     val config = system.settings.config.getConfig(entityTypeName)
     val selfReplicaId = ReplicaId(config.getString("self-replica-id"))
     val grpcClientFallBack = system.settings.config.getConfig("""pekko.grpc.client."*"""")

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/Replication.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/Replication.scala
@@ -80,7 +80,7 @@ object Replication {
    */
   def grpcReplication[Command, Event, State](settings: ReplicationSettings[Command])(
       replicatedBehaviorFactory: ReplicatedBehaviors[Command, Event, State] => Behavior[Command])(
-      implicit system: ActorSystem[_]): Replication[Command] =
+      implicit system: ActorSystem[?]): Replication[Command] =
     grpcReplication[Command, Event, State](settings, (_: EventEnvelope[Event]) => true)(replicatedBehaviorFactory)
 
   /**
@@ -92,7 +92,7 @@ object Replication {
       settings: ReplicationSettings[Command],
       producerFilter: EventEnvelope[Event] => Boolean)(
       replicatedBehaviorFactory: ReplicatedBehaviors[Command, Event, State] => Behavior[Command])(
-      implicit system: ActorSystem[_]): Replication[Command] = {
+      implicit system: ActorSystem[?]): Replication[Command] = {
 
     val replicatedEntity =
       ReplicatedEntity(

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ReplicationProjectionProvider.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ReplicationProjectionProvider.scala
@@ -35,5 +35,5 @@ trait ReplicationProjectionProvider {
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, EventEnvelope[AnyRef]],
       replicationFlow: FlowWithContext[EventEnvelope[AnyRef], ProjectionContext, Done, ProjectionContext, NotUsed],
-      system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, EventEnvelope[AnyRef]]
+      system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, EventEnvelope[AnyRef]]
 }

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ReplicationSettings.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ReplicationSettings.scala
@@ -100,7 +100,7 @@ object ReplicationSettings {
    * client config for reaching the replica from the other replicas.
    */
   def apply[Command](entityTypeName: String, replicationProjectionProvider: scaladsl.ReplicationProjectionProvider)(
-      implicit system: ActorSystem[_],
+      implicit system: ActorSystem[?],
       classTag: ClassTag[Command]): ReplicationSettings[Command] = {
     val config = system.settings.config.getConfig(entityTypeName)
     val entityTypeKey = EntityTypeKey(entityTypeName)

--- a/integration-examples/src/test/scala/docs/cassandra/WordCountDocExample.scala
+++ b/integration-examples/src/test/scala/docs/cassandra/WordCountDocExample.scala
@@ -193,7 +193,7 @@ object WordCountDocExample {
     import org.apache.pekko
     import pekko.projection.scaladsl.ActorHandler
 
-    class WordCountActorHandler(behavior: Behavior[WordCountProcessor.Command])(implicit system: ActorSystem[_])
+    class WordCountActorHandler(behavior: Behavior[WordCountProcessor.Command])(implicit system: ActorSystem[?])
         extends ActorHandler[WordEnvelope, WordCountProcessor.Command](behavior) {
       import pekko.actor.typed.scaladsl.AskPattern._
       import system.executionContext
@@ -294,7 +294,7 @@ object WordCountDocExample {
     import pekko.actor.typed.scaladsl.Behaviors
     import pekko.projection.scaladsl.ActorHandler
 
-    class WordCountActorHandler(behavior: Behavior[WordCountProcessor.Command])(implicit system: ActorSystem[_])
+    class WordCountActorHandler(behavior: Behavior[WordCountProcessor.Command])(implicit system: ActorSystem[?])
         extends ActorHandler[WordEnvelope, WordCountProcessor.Command](behavior) {
       import pekko.actor.typed.scaladsl.AskPattern._
       import system.executionContext

--- a/jdbc-int-test/src/test/scala/org/apache/pekko/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
+++ b/jdbc-int-test/src/test/scala/org/apache/pekko/projection/jdbc/JdbcContainerOffsetStoreSpec.scala
@@ -63,9 +63,9 @@ object JdbcContainerOffsetStoreSpec {
       })
     }
 
-    protected var _container: Option[JdbcDatabaseContainer[_]] = None
+    protected var _container: Option[JdbcDatabaseContainer[?]] = None
 
-    def newContainer(): JdbcDatabaseContainer[_]
+    def newContainer(): JdbcDatabaseContainer[?]
 
     override def initContainer(): Unit = {
       val container = newContainer()
@@ -81,7 +81,7 @@ object JdbcContainerOffsetStoreSpec {
 
   object PostgresSpecConfig extends ContainerJdbcSpecConfig("postgres-dialect") {
     val name = "Postgres Database"
-    override def newContainer(): JdbcDatabaseContainer[_] =
+    override def newContainer(): JdbcDatabaseContainer[?] =
       new PostgreSQLContainer("postgres:18.0").withInitScript("db/default-init.sql")
   }
   object PostgresLegacySchemaSpecConfig extends ContainerJdbcSpecConfig("postgres-dialect") {
@@ -94,20 +94,20 @@ object JdbcContainerOffsetStoreSpec {
         }
         """))
 
-    override def newContainer(): JdbcDatabaseContainer[_] =
+    override def newContainer(): JdbcDatabaseContainer[?] =
       new PostgreSQLContainer("postgres:18.0").withInitScript("db/default-init.sql")
   }
 
   object MySQLSpecConfig extends ContainerJdbcSpecConfig("mysql-dialect") {
     val name = "MySQL Database"
-    override def newContainer(): JdbcDatabaseContainer[_] =
+    override def newContainer(): JdbcDatabaseContainer[?] =
       new MySQLContainer("mysql:9.5.0").withDatabaseName(schemaName)
   }
 
   object MSSQLServerSpecConfig extends ContainerJdbcSpecConfig("mssql-dialect") {
     val name = "MS SQL Server Database"
     override val tag: Tag = TestTags.FlakyDb
-    override def newContainer(): JdbcDatabaseContainer[_] = {
+    override def newContainer(): JdbcDatabaseContainer[?] = {
       val container =
         new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04")
       container.acceptLicense()

--- a/jdbc-int-test/src/test/scala/org/apache/pekko/projection/jdbc/JdbcProjectionSpec.scala
+++ b/jdbc-int-test/src/test/scala/org/apache/pekko/projection/jdbc/JdbcProjectionSpec.scala
@@ -276,7 +276,7 @@ class JdbcProjectionSpec
   }
 
   // TODO: extract this to some utility
-  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[_]): Throwable = {
+  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[?]): Throwable = {
     sinkProbe.expectNextOrError() match {
       case Right(_)  => eventuallyExpectError(sinkProbe)
       case Left(exc) => exc

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcOffsetStore.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcOffsetStore.scala
@@ -46,7 +46,7 @@ import org.slf4j.LoggerFactory
  */
 @InternalApi
 class JdbcOffsetStore[S <: JdbcSession](
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     settings: JdbcSettings,
     jdbcSessionFactory: () => S,
     clock: Clock) {
@@ -54,7 +54,7 @@ class JdbcOffsetStore[S <: JdbcSession](
   private val logger = LoggerFactory.getLogger(this.getClass)
   private val verboseLogging = logger.isDebugEnabled() && settings.verboseLoggingEnabled
 
-  def this(system: ActorSystem[_], settings: JdbcSettings, jdbcSessionFactory: () => S) =
+  def this(system: ActorSystem[?], settings: JdbcSettings, jdbcSessionFactory: () => S) =
     this(system, settings, jdbcSessionFactory, Clock.systemUTC())
 
   private val offsetSerialization = new OffsetSerialization(system)
@@ -134,7 +134,7 @@ class JdbcOffsetStore[S <: JdbcSession](
             if (buffer.isEmpty) None
             else if (buffer.forall(_.mergeable)) {
               Some(
-                fromStorageRepresentation[MergeableOffset[_], Offset](MultipleOffsets(buffer.toList))
+                fromStorageRepresentation[MergeableOffset[?], Offset](MultipleOffsets(buffer.toList))
                   .asInstanceOf[Offset])
             } else {
               buffer.find(_.id == projectionId).map(fromStorageRepresentation[Offset, Offset])

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcProjectionImpl.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcProjectionImpl.scala
@@ -59,7 +59,7 @@ import pekko.stream.scaladsl.Source
 private[projection] object JdbcProjectionImpl {
 
   private[projection] def createOffsetStore[S <: JdbcSession](sessionFactory: () => S)(
-      implicit system: ActorSystem[_]) =
+      implicit system: ActorSystem[?]) =
     new JdbcOffsetStore[S](system, JdbcSettings(system), sessionFactory)
 
   private[projection] def adaptedHandlerForExactlyOnce[Offset, Envelope, S <: JdbcSession](
@@ -185,7 +185,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
   /*
    * Build the final ProjectionSettings to use, if currently set to None fallback to values in config file
    */
-  private def settingsOrDefaults(implicit system: ActorSystem[_]): ProjectionSettings = {
+  private def settingsOrDefaults(implicit system: ActorSystem[?]): ProjectionSettings = {
     val settings = settingsOpt.getOrElse(ProjectionSettings(system))
     restartBackoffOpt match {
       case None    => settings
@@ -239,7 +239,7 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
    * INTERNAL API
    * Return a RunningProjection
    */
-  override private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection =
+  override private[projection] def run()(implicit system: ActorSystem[?]): RunningProjection =
     new JdbcInternalProjectionState(settingsOrDefaults).newRunningInstance()
 
   /**
@@ -248,10 +248,10 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
    * This method returns the projection Source mapped with user 'handler' function, but before any sink attached.
    * This is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
-  override private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
+  override private[projection] def mappedSource()(implicit system: ActorSystem[?]): Source[Done, Future[Done]] =
     new JdbcInternalProjectionState(settingsOrDefaults).mappedSource()
 
-  private class JdbcInternalProjectionState(settings: ProjectionSettings)(implicit val system: ActorSystem[_])
+  private class JdbcInternalProjectionState(settings: ProjectionSettings)(implicit val system: ActorSystem[?])
       extends InternalProjectionState[Offset, Envelope](
         projectionId,
         sourceProvider,
@@ -276,8 +276,8 @@ private[projection] class JdbcProjectionImpl[Offset, Envelope, S <: JdbcSession]
       new JdbcRunningProjection(RunningProjection.withBackoff(() => this.mappedSource(), settings), this)
   }
 
-  private class JdbcRunningProjection(source: Source[Done, _], projectionState: JdbcInternalProjectionState)(
-      implicit system: ActorSystem[_])
+  private class JdbcRunningProjection(source: Source[Done, ?], projectionState: JdbcInternalProjectionState)(
+      implicit system: ActorSystem[?])
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcSettings.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcSettings.scala
@@ -69,7 +69,7 @@ private[projection] object JdbcSettings {
   val configPath = "pekko.projection.jdbc"
   val dispatcherPath: String = configPath + ".use-dispatcher"
 
-  private def checkDispatcherConfig(system: ActorSystem[_]) = {
+  private def checkDispatcherConfig(system: ActorSystem[?]) = {
 
     val dispatcherConfigPath = system.settings.config.getString(dispatcherPath)
     val config = system.settings.config.getConfig(dispatcherConfigPath)
@@ -105,7 +105,7 @@ private[projection] object JdbcSettings {
     }
   }
 
-  def apply(system: ActorSystem[_]): JdbcSettings = {
+  def apply(system: ActorSystem[?]): JdbcSettings = {
     checkDispatcherConfig(system)
     val dispatcherConfigPath = system.settings.config.getString(dispatcherPath)
     val blockingDbDispatcher = system.dispatchers.lookup(DispatcherSelector.fromConfig(dispatcherConfigPath))

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/javadsl/JdbcProjection.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/javadsl/JdbcProjection.scala
@@ -59,7 +59,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionCreator: Supplier[S],
       handler: Supplier[JdbcHandler[Envelope, S]],
-      system: ActorSystem[_]): ExactlyOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): ExactlyOnceProjection[Offset, Envelope] = {
 
     val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
@@ -102,7 +102,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionCreator: Supplier[S],
       handler: Supplier[JdbcHandler[Envelope, S]],
-      system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     val sessionFactory = () => sessionCreator.get()
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
@@ -145,7 +145,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionCreator: Supplier[S],
       handler: Supplier[Handler[Envelope]],
-      system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     val sessionFactory = () => sessionCreator.get()
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)(system)
@@ -177,7 +177,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionCreator: Supplier[S],
       handler: Supplier[JdbcHandler[java.util.List[Envelope], S]],
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
@@ -223,7 +223,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionCreator: Supplier[S],
       handler: Supplier[Handler[java.util.List[Envelope]]],
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
@@ -266,8 +266,8 @@ object JdbcProjection {
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionCreator: Supplier[S],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _],
-      system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, Envelope] = {
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?],
+      system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, Envelope] = {
 
     val sessionFactory = () => sessionCreator.get()
     val javaSourceProvider = new SourceProviderAdapter(sourceProvider)
@@ -292,13 +292,13 @@ object JdbcProjection {
    */
   def createTablesIfNotExists[S <: JdbcSession](
       sessionFactory: Supplier[S],
-      system: ActorSystem[_]): CompletionStage[Done] =
+      system: ActorSystem[?]): CompletionStage[Done] =
     JdbcProjectionImpl.createOffsetStore(() => sessionFactory.get())(system).createIfNotExists().asJava
 
   /**
    * For testing purposes the projection offset and management tables can be dropped programmatically.
    */
-  def dropTablesIfExists[S <: JdbcSession](sessionFactory: Supplier[S], system: ActorSystem[_]): CompletionStage[Done] =
+  def dropTablesIfExists[S <: JdbcSession](sessionFactory: Supplier[S], system: ActorSystem[?]): CompletionStage[Done] =
     JdbcProjectionImpl.createOffsetStore(() => sessionFactory.get())(system).dropIfExists().asJava
 
 }

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/scaladsl/JdbcProjection.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/scaladsl/JdbcProjection.scala
@@ -53,7 +53,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionFactory: () => S,
       handler: () => JdbcHandler[Envelope, S])(
-      implicit system: ActorSystem[_]): ExactlyOnceProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): ExactlyOnceProjection[Offset, Envelope] = {
 
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)
 
@@ -98,7 +98,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionFactory: () => S,
       handler: () => JdbcHandler[Envelope, S])(
-      implicit system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)
 
@@ -136,7 +136,7 @@ object JdbcProjection {
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionFactory: () => S,
-      handler: () => Handler[Envelope])(implicit system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      handler: () => Handler[Envelope])(implicit system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)
 
@@ -167,7 +167,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionFactory: () => S,
       handler: () => JdbcHandler[immutable.Seq[Envelope], S])(
-      implicit system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)
 
@@ -206,7 +206,7 @@ object JdbcProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionFactory: () => S,
       handler: () => Handler[immutable.Seq[Envelope]])(
-      implicit system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)
 
@@ -247,8 +247,8 @@ object JdbcProjection {
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
       sessionFactory: () => S,
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _])(
-      implicit system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, Envelope] = {
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?])(
+      implicit system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, Envelope] = {
 
     val offsetStore = JdbcProjectionImpl.createOffsetStore(sessionFactory)
     new JdbcProjectionImpl(
@@ -269,13 +269,13 @@ object JdbcProjection {
    * before the system is started.
    */
   def createTablesIfNotExists[S <: JdbcSession](sessionFactory: () => S)(
-      implicit system: ActorSystem[_]): Future[Done] =
+      implicit system: ActorSystem[?]): Future[Done] =
     JdbcProjectionImpl.createOffsetStore(sessionFactory).createIfNotExists()
 
   /**
    * For testing purposes the projection offset and management tables can be dropped programmatically.
    */
-  def dropTablesIfExists[S <: JdbcSession](sessionFactory: () => S)(implicit system: ActorSystem[_]): Future[Done] =
+  def dropTablesIfExists[S <: JdbcSession](sessionFactory: () => S)(implicit system: ActorSystem[?]): Future[Done] =
     JdbcProjectionImpl.createOffsetStore(sessionFactory).dropIfExists()
 
 }

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/KafkaOffsets.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/KafkaOffsets.scala
@@ -27,7 +27,7 @@ object KafkaOffsets {
   private val separator = "-"
   private val RegexTp = """(.+)-(\d+)""".r
 
-  def toMergeableOffset(record: ConsumerRecord[_, _]): MergeableOffset[JLong] = {
+  def toMergeableOffset(record: ConsumerRecord[?, ?]): MergeableOffset[JLong] = {
     val key = partitionToKey(new TopicPartition(record.topic(), record.partition()))
     new MergeableOffset[JLong](Map(key -> record.offset()))
   }

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImpl.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImpl.scala
@@ -58,7 +58,7 @@ import org.apache.kafka.common.record.TimestampType
  * INTERNAL API
  */
 @InternalApi private[projection] class KafkaSourceProviderImpl[K, V](
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     settings: ConsumerSettings[K, V],
     topics: Set[String],
     metadataClientFactory: () => MetadataClientAdapter,

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderSettings.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderSettings.scala
@@ -32,7 +32,7 @@ private[projection] final case class KafkaSourceProviderSettings(readOffsetDelay
  */
 @InternalApi
 private[projection] object KafkaSourceProviderSettings {
-  def apply(system: ActorSystem[_]): KafkaSourceProviderSettings = {
+  def apply(system: ActorSystem[?]): KafkaSourceProviderSettings = {
     fromConfig(system.classicSystem.settings.config.getConfig("pekko.projection.kafka"))
   }
 

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/MetadataClientAdapter.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/MetadataClientAdapter.scala
@@ -52,8 +52,8 @@ import org.apache.kafka.common.TopicPartition
  * INTERNAL API
  */
 @InternalApi private[projection] class MetadataClientAdapterImpl(
-    system: ActorSystem[_],
-    settings: ConsumerSettings[_, _])
+    system: ActorSystem[?],
+    settings: ConsumerSettings[?, ?])
     extends MetadataClientAdapter {
   import MetadataClientAdapterImpl._
 

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/javadsl/KafkaSourceProvider.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/javadsl/KafkaSourceProvider.scala
@@ -33,7 +33,7 @@ object KafkaSourceProvider {
    * Create a [[SourceProvider]] that resumes from externally managed offsets
    */
   def create[K, V](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       settings: ConsumerSettings[K, V],
       topics: java.util.Set[String]): SourceProvider[MergeableOffset[JLong], ConsumerRecord[K, V]] = {
     import scala.jdk.CollectionConverters._

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/scaladsl/KafkaSourceProvider.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/scaladsl/KafkaSourceProvider.scala
@@ -33,7 +33,7 @@ object KafkaSourceProvider {
    * Create a [[SourceProvider]] that resumes from externally managed offsets
    */
   def apply[K, V](
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       settings: ConsumerSettings[K, V],
       topics: Set[String]): SourceProvider[MergeableOffset[JLong], ConsumerRecord[K, V]] =
     new KafkaSourceProviderImpl[K, V](

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -23,7 +23,7 @@ trait CopyrightHeader extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  protected def headerMappingSettings: Seq[Def.Setting[_]] =
+  protected def headerMappingSettings: Seq[Def.Setting[?]] =
     Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
@@ -35,10 +35,10 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType("template") -> cStyleComment)))
     }
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override def projectSettings: Seq[Def.Setting[?]] =
     Def.settings(headerMappingSettings, additional)
 
-  def additional: Seq[Def.Setting[_]] =
+  def additional: Seq[Def.Setting[?]] =
     Def.settings(Compile / compile := {
         (Compile / headerCreate).value
         (Compile / compile).value

--- a/project/Protobuf.scala
+++ b/project/Protobuf.scala
@@ -31,7 +31,7 @@ object Protobuf {
   val protocVersion = SettingKey[String]("protobuf-protoc-version", "The version of the protoc executable.")
   val generate = TaskKey[Unit]("protobuf-generate", "Compile the protobuf sources and do all processing.")
 
-  lazy val settings: Seq[Setting[_]] = Seq(
+  lazy val settings: Seq[Setting[?]] = Seq(
     paths := Seq((Compile / sourceDirectory).value, (Test / sourceDirectory).value).map(_ / "protobuf"),
     outputPaths := Seq((Compile / sourceDirectory).value, (Test / sourceDirectory).value).map(_ / "java"),
     importPath := None,

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/DurableStateEndToEndSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/DurableStateEndToEndSpec.scala
@@ -126,7 +126,7 @@ class DurableStateEndToEndSpec
     with LogCapturing {
   import DurableStateEndToEndSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val settings = R2dbcProjectionSettings(testKit.system)
 

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/EventSourcedChaosSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/EventSourcedChaosSpec.scala
@@ -110,7 +110,7 @@ class EventSourcedChaosSpec
     with LogCapturing {
   import EventSourcedEndToEndSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val settings = R2dbcProjectionSettings(testKit.system)
   private val log = LoggerFactory.getLogger(getClass)

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/EventSourcedEndToEndSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/EventSourcedEndToEndSpec.scala
@@ -137,7 +137,7 @@ class EventSourcedEndToEndSpec
     with LogCapturing {
   import EventSourcedEndToEndSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val log = LoggerFactory.getLogger(getClass)
 

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/EventSourcedPubSubSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/EventSourcedPubSubSpec.scala
@@ -98,7 +98,7 @@ class EventSourcedPubSubSpec
   import EventSourcedEndToEndSpec.Persister
   import EventSourcedPubSubSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private implicit val ec: ExecutionContext = system.executionContext
 
   private val log = LoggerFactory.getLogger(getClass)

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcOffsetStoreSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcOffsetStoreSpec.scala
@@ -38,7 +38,7 @@ class R2dbcOffsetStoreSpec
     with TestData
     with LogCapturing {
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   // test clock for testing of the `last_updated` Instant
   private val clock = TestClock.nowMillis()

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSpec.scala
@@ -111,7 +111,7 @@ object R2dbcProjectionSpec {
   }
 
   final case class TestRepository(session: R2dbcSession, settings: R2dbcProjectionSettings)(
-      implicit ec: ExecutionContext, system: ActorSystem[_]) {
+      implicit ec: ExecutionContext, system: ActorSystem[?]) {
     import TestRepository.table
 
     private val logger = LoggerFactory.getLogger(this.getClass)
@@ -193,7 +193,7 @@ class R2dbcProjectionSpec
     with LogCapturing {
   import R2dbcProjectionSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private implicit val ec: ExecutionContext = system.executionContext
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -248,7 +248,7 @@ class R2dbcProjectionSpec
   }
 
   // TODO: extract this to some utility
-  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[_]): Throwable = {
+  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[?]): Throwable = {
     sinkProbe.expectNextOrError() match {
       case Right(_)  => eventuallyExpectError(sinkProbe)
       case Left(exc) => exc

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcTimestampOffsetProjectionSpec.scala
@@ -147,7 +147,7 @@ class R2dbcTimestampOffsetProjectionSpec
   import R2dbcProjectionSpec.TestRepository
   import R2dbcTimestampOffsetProjectionSpec._
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
   private implicit val ec: ExecutionContext = system.executionContext
 
   private val logger = LoggerFactory.getLogger(getClass)
@@ -210,7 +210,7 @@ class R2dbcTimestampOffsetProjectionSpec
   }
 
   // TODO: extract this to some utility
-  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[_]): Throwable = {
+  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[?]): Throwable = {
     sinkProbe.expectNextOrError() match {
       case Right(_)  => eventuallyExpectError(sinkProbe)
       case Left(exc) => exc

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -69,7 +69,7 @@ class R2dbcTimestampOffsetStoreSpec
     with LogCapturing {
   import R2dbcTimestampOffsetStoreSpec.TestTimestampSourceProvider
 
-  override def typedSystem: ActorSystem[_] = system
+  override def typedSystem: ActorSystem[?] = system
 
   private val clock = TestClock.nowMicros()
   def tick(): Unit = clock.tick(JDuration.ofMillis(1))

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/TestDbLifecycle.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/TestDbLifecycle.scala
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory
 
 trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
 
-  def typedSystem: ActorSystem[_]
+  def typedSystem: ActorSystem[?]
 
   def testConfigPath: String = "pekko.projection.r2dbc"
 

--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/TestSourceProviderWithInput.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/TestSourceProviderWithInput.scala
@@ -37,7 +37,7 @@ import pekko.projection.scaladsl.SourceProvider
 import pekko.stream.OverflowStrategy
 import pekko.stream.scaladsl.Source
 
-class TestSourceProviderWithInput()(implicit val system: ActorSystem[_])
+class TestSourceProviderWithInput()(implicit val system: ActorSystem[?])
     extends SourceProvider[TimestampOffset, EventEnvelope[String]]
     with BySlicesSourceProvider
     with EventTimestampQuery

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -64,17 +64,17 @@ object R2dbcProjectionSettings {
    * Java API: Load configuration from `pekko.projection.r2dbc`.
    * @since 2.0.0
    */
-  def create(system: ActorSystem[_]): R2dbcProjectionSettings =
+  def create(system: ActorSystem[?]): R2dbcProjectionSettings =
     apply(system)
 
   /**
    * Scala API: Load configuration from `pekko.projection.r2dbc`.
    */
-  def apply(system: ActorSystem[_]): R2dbcProjectionSettings =
+  def apply(system: ActorSystem[?]): R2dbcProjectionSettings =
     apply(system.settings.config.getConfig(DefaultConfigPath))
 
   /** @since 2.0.0 */
-  def apply(config: Config, system: ActorSystem[_]): R2dbcProjectionSettings =
+  def apply(config: Config, system: ActorSystem[?]): R2dbcProjectionSettings =
     apply(config.withFallback(system.settings.config.getConfig(DefaultConfigPath)))
 
   def apply(

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -181,7 +181,7 @@ private[projection] object R2dbcOffsetStore {
   def fromConfig(
       projectionId: ProjectionId,
       sourceProvider: Option[BySlicesSourceProvider],
-      system: ActorSystem[_],
+      system: ActorSystem[?],
       settings: R2dbcProjectionSettings,
       r2dbcExecutor: R2dbcExecutor,
       clock: Clock = Clock.systemUTC()
@@ -219,7 +219,7 @@ private[projection] object R2dbcOffsetStore {
 private[projection] class R2dbcOffsetStore(
     projectionId: ProjectionId,
     sourceProvider: Option[BySlicesSourceProvider],
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     settings: R2dbcProjectionSettings,
     r2dbcExecutor: R2dbcExecutor,
     clock: Clock = Clock.systemUTC()) {
@@ -443,7 +443,7 @@ private[projection] class R2dbcOffsetStore(
           if (offsets.isEmpty) None
           else if (offsets.forall(_.mergeable)) {
             Some(
-              fromStorageRepresentation[MergeableOffset[_], Offset](MultipleOffsets(offsets.toList))
+              fromStorageRepresentation[MergeableOffset[?], Offset](MultipleOffsets(offsets.toList))
                 .asInstanceOf[Offset])
           } else {
             offsets.find(_.id == projectionId).map(fromStorageRepresentation[Offset, Offset])
@@ -1101,7 +1101,7 @@ private[projection] class R2dbcOffsetStore(
 
   private def createRecordWithOffset[Envelope](envelope: Envelope): Option[RecordWithOffset] = {
     envelope match {
-      case eventEnvelope: EventEnvelope[_] if eventEnvelope.offset.isInstanceOf[TimestampOffset] =>
+      case eventEnvelope: EventEnvelope[?] if eventEnvelope.offset.isInstanceOf[TimestampOffset] =>
         val timestampOffset = eventEnvelope.offset.asInstanceOf[TimestampOffset]
         val slice = persistenceExt.sliceForPersistenceId(eventEnvelope.persistenceId)
         Some(
@@ -1111,7 +1111,7 @@ private[projection] class R2dbcOffsetStore(
             strictSeqNr = true,
             fromBacktracking = EnvelopeOrigin.fromBacktracking(eventEnvelope),
             fromPubSub = EnvelopeOrigin.fromPubSub(eventEnvelope)))
-      case change: UpdatedDurableState[_] if change.offset.isInstanceOf[TimestampOffset] =>
+      case change: UpdatedDurableState[?] if change.offset.isInstanceOf[TimestampOffset] =>
         val timestampOffset = change.offset.asInstanceOf[TimestampOffset]
         val slice = persistenceExt.sliceForPersistenceId(change.persistenceId)
         Some(
@@ -1121,7 +1121,7 @@ private[projection] class R2dbcOffsetStore(
             strictSeqNr = false,
             fromBacktracking = false,
             fromPubSub = false))
-      case change: DeletedDurableState[_] if change.offset.isInstanceOf[TimestampOffset] =>
+      case change: DeletedDurableState[?] if change.offset.isInstanceOf[TimestampOffset] =>
         val timestampOffset = change.offset.asInstanceOf[TimestampOffset]
         val slice = persistenceExt.sliceForPersistenceId(change.persistenceId)
         Some(
@@ -1131,7 +1131,7 @@ private[projection] class R2dbcOffsetStore(
             strictSeqNr = false,
             fromBacktracking = false,
             fromPubSub = false))
-      case change: DurableStateChange[_] if change.offset.isInstanceOf[TimestampOffset] =>
+      case change: DurableStateChange[?] if change.offset.isInstanceOf[TimestampOffset] =>
         // in case additional types are added
         throw new IllegalArgumentException(
           s"DurableStateChange [${change.getClass.getName}] not implemented yet. Please report bug at https://github.com/apache/pekko-projection/issues")

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -85,7 +85,7 @@ private[projection] object R2dbcProjectionImpl {
   import pekko.persistence.r2dbc.internal.EnvelopeOrigin.fromBacktracking
   import pekko.persistence.r2dbc.internal.EnvelopeOrigin.isFilteredEvent
 
-  val log: Logger = LoggerFactory.getLogger(classOf[R2dbcProjectionImpl[_, _]])
+  val log: Logger = LoggerFactory.getLogger(classOf[R2dbcProjectionImpl[?, ?]])
 
   private val FutureDone: Future[Done] = Future.successful(Done)
 
@@ -93,7 +93,7 @@ private[projection] object R2dbcProjectionImpl {
       projectionId: ProjectionId,
       sourceProvider: Option[BySlicesSourceProvider],
       settings: R2dbcProjectionSettings,
-      connectionFactory: ConnectionFactory)(implicit system: ActorSystem[_]) = {
+      connectionFactory: ConnectionFactory)(implicit system: ActorSystem[?]) = {
     val r2dbcExecutor =
       new R2dbcExecutor(connectionFactory, log, settings.logDbCallsExceeding)(system.executionContext, system)
     R2dbcOffsetStore.fromConfig(projectionId, sourceProvider, system, settings, r2dbcExecutor)
@@ -101,11 +101,11 @@ private[projection] object R2dbcProjectionImpl {
 
   private val loadEnvelopeCounter = new AtomicLong
 
-  def loadEnvelope[Envelope](env: Envelope, sourceProvider: SourceProvider[_, Envelope])(
+  def loadEnvelope[Envelope](env: Envelope, sourceProvider: SourceProvider[?, Envelope])(
       implicit
       ec: ExecutionContext): Future[Envelope] = {
     env match {
-      case eventEnvelope: EventEnvelope[_]
+      case eventEnvelope: EventEnvelope[?]
           if fromBacktracking(eventEnvelope) && eventEnvelope.eventOption.isEmpty && !eventEnvelope.filtered =>
         val pid = eventEnvelope.persistenceId
         val seqNr = eventEnvelope.sequenceNr
@@ -128,12 +128,12 @@ private[projection] object R2dbcProjectionImpl {
           loadedEnv.asInstanceOf[Envelope]
         }
 
-      case upd: UpdatedDurableState[_] if upd.value == null =>
+      case upd: UpdatedDurableState[?] if upd.value == null =>
         val pid = upd.persistenceId
         (sourceProvider match {
-          case store: DurableStateStore[_] =>
+          case store: DurableStateStore[?] =>
             store.getObject(pid)
-          case store: pekko.persistence.state.javadsl.DurableStateStore[_] =>
+          case store: pekko.persistence.state.javadsl.DurableStateStore[?] =>
             import scala.jdk.FutureConverters._
             store.getObject(pid).asScala.map(_.toScala)
           case unknown =>
@@ -173,9 +173,9 @@ private[projection] object R2dbcProjectionImpl {
   private def extractOffsetPidSeqNr[Offset, Envelope](offset: Offset, envelope: Envelope): OffsetPidSeqNr = {
     // we could define a new trait for the SourceProvider to implement this in case other (custom) envelope types are needed
     envelope match {
-      case env: EventEnvelope[_]       => OffsetPidSeqNr(offset, env.persistenceId, env.sequenceNr)
-      case chg: UpdatedDurableState[_] => OffsetPidSeqNr(offset, chg.persistenceId, chg.revision)
-      case del: DeletedDurableState[_] => OffsetPidSeqNr(offset, del.persistenceId, del.revision)
+      case env: EventEnvelope[?]       => OffsetPidSeqNr(offset, env.persistenceId, env.sequenceNr)
+      case chg: UpdatedDurableState[?] => OffsetPidSeqNr(offset, chg.persistenceId, chg.revision)
+      case del: DeletedDurableState[?] => OffsetPidSeqNr(offset, del.persistenceId, del.revision)
       case _                           => OffsetPidSeqNr(offset)
     }
   }
@@ -184,7 +184,7 @@ private[projection] object R2dbcProjectionImpl {
       sourceProvider: SourceProvider[Offset, Envelope],
       handlerFactory: () => R2dbcHandler[Envelope],
       offsetStore: R2dbcOffsetStore,
-      r2dbcExecutor: R2dbcExecutor)(implicit ec: ExecutionContext, system: ActorSystem[_]): () => Handler[Envelope] = {
+      r2dbcExecutor: R2dbcExecutor)(implicit ec: ExecutionContext, system: ActorSystem[?]): () => Handler[Envelope] = {
     () =>
       new AdaptedR2dbcHandler(handlerFactory()) {
         override def process(envelope: Envelope): Future[Done] = {
@@ -232,7 +232,7 @@ private[projection] object R2dbcProjectionImpl {
       r2dbcExecutor: R2dbcExecutor)(
       implicit
       ec: ExecutionContext,
-      system: ActorSystem[_]): () => Handler[immutable.Seq[Envelope]] = { () =>
+      system: ActorSystem[?]): () => Handler[immutable.Seq[Envelope]] = { () =>
     new AdaptedR2dbcHandler(handlerFactory()) {
       override def process(envelopes: immutable.Seq[Envelope]): Future[Done] = {
         import R2dbcOffsetStore.Validation._
@@ -281,7 +281,7 @@ private[projection] object R2dbcProjectionImpl {
       sourceProvider: SourceProvider[Offset, Envelope],
       handlerFactory: () => R2dbcHandler[Envelope],
       offsetStore: R2dbcOffsetStore,
-      r2dbcExecutor: R2dbcExecutor)(implicit ec: ExecutionContext, system: ActorSystem[_]): () => Handler[Envelope] = {
+      r2dbcExecutor: R2dbcExecutor)(implicit ec: ExecutionContext, system: ActorSystem[?]): () => Handler[Envelope] = {
     () =>
       new AdaptedR2dbcHandler(handlerFactory()) {
         override def process(envelope: Envelope): Future[Done] = {
@@ -325,7 +325,7 @@ private[projection] object R2dbcProjectionImpl {
   private[projection] def adaptedHandlerForAtLeastOnceAsync[Offset, Envelope](
       sourceProvider: SourceProvider[Offset, Envelope],
       handlerFactory: () => Handler[Envelope],
-      offsetStore: R2dbcOffsetStore)(implicit ec: ExecutionContext, system: ActorSystem[_]): () => Handler[Envelope] = {
+      offsetStore: R2dbcOffsetStore)(implicit ec: ExecutionContext, system: ActorSystem[?]): () => Handler[Envelope] = {
     () =>
       new AdaptedHandler(handlerFactory()) {
         override def process(envelope: Envelope): Future[Done] = {
@@ -368,7 +368,7 @@ private[projection] object R2dbcProjectionImpl {
       offsetStore: R2dbcOffsetStore)(
       implicit
       ec: ExecutionContext,
-      system: ActorSystem[_]): () => Handler[immutable.Seq[Envelope]] = { () =>
+      system: ActorSystem[?]): () => Handler[immutable.Seq[Envelope]] = { () =>
     new AdaptedHandler(handlerFactory()) {
       override def process(envelopes: immutable.Seq[Envelope]): Future[Done] = {
         import R2dbcOffsetStore.Validation._
@@ -411,10 +411,10 @@ private[projection] object R2dbcProjectionImpl {
 
   private[projection] def adaptedHandlerForFlow[Offset, Envelope](
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _],
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?],
       offsetStore: R2dbcOffsetStore,
       settings: R2dbcProjectionSettings)(
-      implicit system: ActorSystem[_]): FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _] = {
+      implicit system: ActorSystem[?]): FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?] = {
     import R2dbcOffsetStore.Validation._
     implicit val ec: ExecutionContext = system.executionContext
     FlowWithContext[Envelope, ProjectionContext]
@@ -484,7 +484,7 @@ private[projection] object R2dbcProjectionImpl {
   abstract class AdaptedR2dbcHandler[E](val delegate: R2dbcHandler[E])(
       implicit
       ec: ExecutionContext,
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends Handler[E] {
 
     override def start(): Future[Done] =
@@ -495,7 +495,7 @@ private[projection] object R2dbcProjectionImpl {
   }
 
   @nowarn("msg=never used")
-  abstract class AdaptedHandler[E](val delegate: Handler[E])(implicit ec: ExecutionContext, system: ActorSystem[_])
+  abstract class AdaptedHandler[E](val delegate: Handler[E])(implicit ec: ExecutionContext, system: ActorSystem[?])
       extends Handler[E] {
 
     override def start(): Future[Done] =
@@ -554,7 +554,7 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
   /*
    * Build the final ProjectionSettings to use, if currently set to None fallback to values in config file
    */
-  private def settingsOrDefaults(implicit system: ActorSystem[_]): ProjectionSettings = {
+  private def settingsOrDefaults(implicit system: ActorSystem[?]): ProjectionSettings = {
     val settings = settingsOpt.getOrElse(ProjectionSettings(system))
     restartBackoffOpt match {
       case None    => settings
@@ -601,7 +601,7 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
   /**
    * INTERNAL API Return a RunningProjection
    */
-  override private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection =
+  override private[projection] def run()(implicit system: ActorSystem[?]): RunningProjection =
     new R2dbcInternalProjectionState(settingsOrDefaults).newRunningInstance()
 
   /**
@@ -610,10 +610,10 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
    * This method returns the projection Source mapped with user 'handler' function, but before any sink attached. This
    * is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
-  override private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
+  override private[projection] def mappedSource()(implicit system: ActorSystem[?]): Source[Done, Future[Done]] =
     new R2dbcInternalProjectionState(settingsOrDefaults).mappedSource()
 
-  private class R2dbcInternalProjectionState(settings: ProjectionSettings)(implicit val system: ActorSystem[_])
+  private class R2dbcInternalProjectionState(settings: ProjectionSettings)(implicit val system: ActorSystem[?])
       extends InternalProjectionState[Offset, Envelope](
         projectionId,
         sourceProvider,
@@ -623,7 +623,7 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
         settings) {
 
     implicit val executionContext: ExecutionContext = system.executionContext
-    override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[R2dbcProjectionImpl[_, _]])
+    override val logger: LoggingAdapter = Logging(system.classicSystem, classOf[R2dbcProjectionImpl[?, ?]])
 
     private val isExactlyOnceWithSkip: Boolean =
       offsetStrategy match {
@@ -710,9 +710,9 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
       new R2dbcRunningProjection(RunningProjection.withBackoff(() => this.mappedSource(), settings), this)
   }
 
-  private class R2dbcRunningProjection(source: Source[Done, _], projectionState: R2dbcInternalProjectionState)(
+  private class R2dbcRunningProjection(source: Source[Done, ?], projectionState: R2dbcInternalProjectionState)(
       implicit
-      system: ActorSystem[_])
+      system: ActorSystem[?])
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/mysql/MySQLR2dbcOffsetStore.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/mysql/MySQLR2dbcOffsetStore.scala
@@ -65,7 +65,7 @@ private[projection] object MySQLR2dbcOffsetStore {
 private[projection] class MySQLR2dbcOffsetStore(
     projectionId: ProjectionId,
     sourceProvider: Option[BySlicesSourceProvider],
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     settings: R2dbcProjectionSettings,
     r2dbcExecutor: R2dbcExecutor,
     clock: Clock = Clock.systemUTC())

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcProjection.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcProjection.scala
@@ -55,7 +55,7 @@ object R2dbcProjection {
       settings: Optional[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: Supplier[R2dbcHandler[Envelope]],
-      system: ActorSystem[_]): ExactlyOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): ExactlyOnceProjection[Offset, Envelope] = {
     scaladsl.R2dbcProjection
       .exactlyOnce[Offset, Envelope](
         projectionId,
@@ -84,7 +84,7 @@ object R2dbcProjection {
       settings: Optional[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: Supplier[R2dbcHandler[Envelope]],
-      system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
     scaladsl.R2dbcProjection
       .atLeastOnce[Offset, Envelope](
         projectionId,
@@ -113,7 +113,7 @@ object R2dbcProjection {
       settings: Optional[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: Supplier[Handler[Envelope]],
-      system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     scaladsl.R2dbcProjection
       .atLeastOnceAsync[Offset, Envelope](
@@ -138,7 +138,7 @@ object R2dbcProjection {
       settings: Optional[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: Supplier[R2dbcHandler[java.util.List[Envelope]]],
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
     scaladsl.R2dbcProjection
       .groupedWithin[Offset, Envelope](
         projectionId,
@@ -166,7 +166,7 @@ object R2dbcProjection {
       settings: Optional[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: Supplier[Handler[java.util.List[Envelope]]],
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
     scaladsl.R2dbcProjection
       .groupedWithinAsync[Offset, Envelope](
         projectionId,
@@ -201,8 +201,8 @@ object R2dbcProjection {
       projectionId: ProjectionId,
       settings: Optional[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _],
-      system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, Envelope] = {
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?],
+      system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, Envelope] = {
     scaladsl.R2dbcProjection
       .atLeastOnceFlow[Offset, Envelope](
         projectionId,

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcReplication.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcReplication.scala
@@ -26,7 +26,7 @@ object R2dbcReplication {
    * Creates a projection provider for using R2dbc as backend for the Pekko Projection gRPC transport for Replicated
    * Event Sourcing.
    */
-  def create(system: ActorSystem[_]): ReplicationProjectionProvider =
+  def create(system: ActorSystem[?]): ReplicationProjectionProvider =
     R2dbcProjection.atLeastOnceFlow(
       _,
       Optional.of(R2dbcProjectionSettings(system).withWarnAboutFilteredEventsInFlow(false)),

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcSession.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcSession.scala
@@ -30,7 +30,7 @@ import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 
 @ApiMayChange
-final class R2dbcSession(connection: Connection)(implicit ec: ExecutionContext, system: ActorSystem[_]) {
+final class R2dbcSession(connection: Connection)(implicit ec: ExecutionContext, system: ActorSystem[?]) {
 
   def createStatement(sql: String): Statement =
     connection.createStatement(sql)

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcProjection.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcProjection.scala
@@ -58,7 +58,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => R2dbcHandler[Envelope])(implicit
-      system: ActorSystem[_]): ExactlyOnceProjection[Offset, Envelope] =
+      system: ActorSystem[?]): ExactlyOnceProjection[Offset, Envelope] =
     exactlyOnce(projectionId, ConfigFactory.empty(), settings, sourceProvider, handler)
 
   /** @since 2.0.0 */
@@ -68,7 +68,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => R2dbcHandler[Envelope])(implicit
-      system: ActorSystem[_]): ExactlyOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): ExactlyOnceProjection[Offset, Envelope] = {
     val r2dbcSettings = settings.getOrElse(R2dbcProjectionSettings(config, system))
     val connFactory = connectionFactory(system, config, r2dbcSettings)
     val offsetStore =
@@ -117,7 +117,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => R2dbcHandler[Envelope])(implicit
-      system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] =
+      system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] =
     atLeastOnce(projectionId, ConfigFactory.empty(), settings, sourceProvider, handler)
 
   /** @since 2.0.0 */
@@ -127,7 +127,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => R2dbcHandler[Envelope])(implicit
-      system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     val r2dbcSettings = settings.getOrElse(R2dbcProjectionSettings(config, system))
     val connFactory = connectionFactory(system, config, r2dbcSettings)
@@ -176,7 +176,7 @@ object R2dbcProjection {
       projectionId: ProjectionId,
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: () => Handler[Envelope])(implicit system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] =
+      handler: () => Handler[Envelope])(implicit system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] =
     atLeastOnceAsync(projectionId, ConfigFactory.empty(), settings, sourceProvider, handler)
 
   /** @since 2.0.0 */
@@ -185,7 +185,7 @@ object R2dbcProjection {
       config: Config,
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: () => Handler[Envelope])(implicit system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      handler: () => Handler[Envelope])(implicit system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     val r2dbcSettings = settings.getOrElse(R2dbcProjectionSettings(config, system))
     val connFactory = connectionFactory(system, config, r2dbcSettings)
@@ -227,7 +227,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => R2dbcHandler[immutable.Seq[Envelope]])(implicit
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] =
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] =
     groupedWithin(projectionId, ConfigFactory.empty(), settings, sourceProvider, handler)
 
   /** @since 2.0.0 */
@@ -237,7 +237,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => R2dbcHandler[immutable.Seq[Envelope]])(implicit
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val r2dbcSettings = settings.getOrElse(R2dbcProjectionSettings(config, system))
     val connFactory = connectionFactory(system, config, r2dbcSettings)
@@ -286,7 +286,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => Handler[immutable.Seq[Envelope]])(implicit
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] =
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] =
     groupedWithinAsync(projectionId, ConfigFactory.empty(), settings, sourceProvider, handler)
 
   /** @since 2.0.0 */
@@ -296,7 +296,7 @@ object R2dbcProjection {
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
       handler: () => Handler[immutable.Seq[Envelope]])(implicit
-      system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val r2dbcSettings = settings.getOrElse(R2dbcProjectionSettings(config, system))
     val connFactory = connectionFactory(system, config, r2dbcSettings)
@@ -349,8 +349,8 @@ object R2dbcProjection {
       projectionId: ProjectionId,
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _])(implicit
-      system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, Envelope] =
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?])(implicit
+      system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, Envelope] =
     atLeastOnceFlow(projectionId, ConfigFactory.empty(), settings, sourceProvider, handler)
 
   /** @since 2.0.0 */
@@ -359,8 +359,8 @@ object R2dbcProjection {
       config: Config,
       settings: Option[R2dbcProjectionSettings],
       sourceProvider: SourceProvider[Offset, Envelope],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _])(implicit
-      system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, Envelope] = {
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?])(implicit
+      system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, Envelope] = {
 
     val r2dbcSettings = settings.getOrElse(R2dbcProjectionSettings(config, system))
     val connFactory = connectionFactory(system, config, r2dbcSettings)
@@ -386,13 +386,13 @@ object R2dbcProjection {
       offsetStore)
   }
 
-  private def connectionFactory(system: ActorSystem[_], config: Config, r2dbcSettings: R2dbcProjectionSettings)
+  private def connectionFactory(system: ActorSystem[?], config: Config, r2dbcSettings: R2dbcProjectionSettings)
       : ConnectionFactory = {
     ConnectionFactoryProvider(system).connectionFactoryFor(r2dbcSettings.useConnectionFactory, config)
   }
 
   private def timestampOffsetBySlicesSourceProvider(
-      sourceProvider: SourceProvider[_, _]): Option[BySlicesSourceProvider] = {
+      sourceProvider: SourceProvider[?, ?]): Option[BySlicesSourceProvider] = {
     sourceProvider match {
       case provider: BySlicesSourceProvider => Some(provider)
       case _                                => None // source provider is not using slices

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcReplication.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcReplication.scala
@@ -24,7 +24,7 @@ object R2dbcReplication {
    * Creates a projection provider for using R2dbc as backend for the Pekko Projection gRPC transport for Replicated
    * Event Sourcing.
    */
-  def apply()(implicit system: ActorSystem[_]): ReplicationProjectionProvider =
+  def apply()(implicit system: ActorSystem[?]): ReplicationProjectionProvider =
     R2dbcProjection.atLeastOnceFlow(
       _,
       Some(R2dbcProjectionSettings(system).withWarnAboutFilteredEventsInFlow(false)),

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcSession.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcSession.scala
@@ -24,7 +24,7 @@ import io.r2dbc.spi.Connection
 import io.r2dbc.spi.Row
 import io.r2dbc.spi.Statement
 
-final class R2dbcSession(val connection: Connection)(implicit val ec: ExecutionContext, val system: ActorSystem[_]) {
+final class R2dbcSession(val connection: Connection)(implicit val ec: ExecutionContext, val system: ActorSystem[?]) {
 
   def createStatement(sql: String): Statement =
     connection.createStatement(sql)

--- a/slick-int-test/src/test/scala/org/apache/pekko/projection/slick/SlickContainerOffsetStoreSpec.scala
+++ b/slick-int-test/src/test/scala/org/apache/pekko/projection/slick/SlickContainerOffsetStoreSpec.scala
@@ -33,7 +33,7 @@ object SlickContainerOffsetStoreSpec {
   abstract class ContainerJdbcSpecConfig extends SlickSpecConfig {
 
     val tag: Tag = TestTags.ContainerDb
-    def container: JdbcDatabaseContainer[_]
+    def container: JdbcDatabaseContainer[?]
 
     override def config = {
       baseConfig.withFallback(ConfigFactory.parseString(s"""
@@ -51,7 +51,7 @@ object SlickContainerOffsetStoreSpec {
 
     }
 
-    protected def initContainer(container: JdbcDatabaseContainer[_]): JdbcDatabaseContainer[_] = {
+    protected def initContainer(container: JdbcDatabaseContainer[?]): JdbcDatabaseContainer[?] = {
       container.withStartupCheckStrategy(new IsRunningStartupCheckStrategy)
       container.withStartupAttempts(5)
       container.start()
@@ -110,7 +110,7 @@ object SlickContainerOffsetStoreSpec {
 
     val container = initContainer(new MSSQLServerContainer("mcr.microsoft.com/mssql/server:2019-CU32-ubuntu-20.04"))
 
-    override protected def initContainer(container: JdbcDatabaseContainer[_]): JdbcDatabaseContainer[_] = {
+    override protected def initContainer(container: JdbcDatabaseContainer[?]): JdbcDatabaseContainer[?] = {
       container.asInstanceOf[MSSQLServerContainer].acceptLicense()
       container.withUrlParam("integratedSecurity", "false")
       container.withUrlParam("encrypt", "false")

--- a/slick/src/main/scala/org/apache/pekko/projection/slick/SlickProjection.scala
+++ b/slick/src/main/scala/org/apache/pekko/projection/slick/SlickProjection.scala
@@ -69,7 +69,7 @@ object SlickProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       databaseConfig: DatabaseConfig[P],
       handler: () => SlickHandler[Envelope])(
-      implicit system: ActorSystem[_]): ExactlyOnceProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): ExactlyOnceProjection[Offset, Envelope] = {
 
     val offsetStore = createOffsetStore(databaseConfig)
 
@@ -77,7 +77,7 @@ object SlickProjection {
       new Handler[Envelope] {
 
         private implicit val ec: ExecutionContext = system.executionContext
-        private val logger = Logging(system.classicSystem, classOf[SlickProjectionImpl[_, _, _]])
+        private val logger = Logging(system.classicSystem, classOf[SlickProjectionImpl[?, ?, ?]])
         private val delegate = handler()
 
         import databaseConfig.profile.api._
@@ -150,7 +150,7 @@ object SlickProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       databaseConfig: DatabaseConfig[P],
       handler: () => SlickHandler[Envelope])(
-      implicit system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     import databaseConfig.profile.api._
 
@@ -199,7 +199,7 @@ object SlickProjection {
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
       databaseConfig: DatabaseConfig[P],
-      handler: () => Handler[Envelope])(implicit system: ActorSystem[_]): AtLeastOnceProjection[Offset, Envelope] = {
+      handler: () => Handler[Envelope])(implicit system: ActorSystem[?]): AtLeastOnceProjection[Offset, Envelope] = {
 
     new SlickProjectionImpl(
       projectionId,
@@ -228,7 +228,7 @@ object SlickProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       databaseConfig: DatabaseConfig[P],
       handler: () => SlickHandler[immutable.Seq[Envelope]])(
-      implicit system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val offsetStore = createOffsetStore(databaseConfig)
 
@@ -237,7 +237,7 @@ object SlickProjection {
 
         import databaseConfig.profile.api._
         private implicit val ec: ExecutionContext = system.executionContext
-        private val logger = Logging(system.classicSystem, classOf[SlickProjectionImpl[_, _, _]])
+        private val logger = Logging(system.classicSystem, classOf[SlickProjectionImpl[?, ?, ?]])
         private val delegate = handler()
 
         override def process(envelopes: immutable.Seq[Envelope]): Future[Done] = {
@@ -309,7 +309,7 @@ object SlickProjection {
       sourceProvider: SourceProvider[Offset, Envelope],
       databaseConfig: DatabaseConfig[P],
       handler: () => Handler[immutable.Seq[Envelope]])(
-      implicit system: ActorSystem[_]): GroupedProjection[Offset, Envelope] = {
+      implicit system: ActorSystem[?]): GroupedProjection[Offset, Envelope] = {
 
     val offsetStore = createOffsetStore(databaseConfig)
 
@@ -350,8 +350,8 @@ object SlickProjection {
       projectionId: ProjectionId,
       sourceProvider: SourceProvider[Offset, Envelope],
       databaseConfig: DatabaseConfig[P],
-      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, _])(
-      implicit system: ActorSystem[_]): AtLeastOnceFlowProjection[Offset, Envelope] = {
+      handler: FlowWithContext[Envelope, ProjectionContext, Done, ProjectionContext, ?])(
+      implicit system: ActorSystem[?]): AtLeastOnceFlowProjection[Offset, Envelope] = {
 
     new SlickProjectionImpl(
       projectionId,
@@ -371,7 +371,7 @@ object SlickProjection {
    * before the system is started.
    */
   def createTablesIfNotExists[P <: JdbcProfile: ClassTag](databaseConfig: DatabaseConfig[P])(
-      implicit system: ActorSystem[_]): Future[Done] = {
+      implicit system: ActorSystem[?]): Future[Done] = {
     createOffsetStore(databaseConfig).createIfNotExists()
   }
 
@@ -379,12 +379,12 @@ object SlickProjection {
    * For testing purposes the projection offset and management tables can be dropped programmatically.
    */
   def dropTablesIfExists[P <: JdbcProfile: ClassTag](databaseConfig: DatabaseConfig[P])(
-      implicit system: ActorSystem[_]): Future[Done] = {
+      implicit system: ActorSystem[?]): Future[Done] = {
     createOffsetStore(databaseConfig).dropIfExists()
   }
 
   private def createOffsetStore[P <: JdbcProfile: ClassTag](databaseConfig: DatabaseConfig[P])(
-      implicit system: ActorSystem[_]) =
+      implicit system: ActorSystem[?]) =
     new SlickOffsetStore(system, databaseConfig, SlickSettings(system))
 }
 

--- a/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickOffsetStore.scala
+++ b/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickOffsetStore.scala
@@ -40,12 +40,12 @@ import slick.jdbc.JdbcProfile
  * INTERNAL API
  */
 @InternalApi private[projection] class SlickOffsetStore[P <: JdbcProfile](
-    system: ActorSystem[_],
+    system: ActorSystem[?],
     databaseConfig: DatabaseConfig[P],
     slickSettings: SlickSettings,
     clock: Clock) {
 
-  def this(system: ActorSystem[_], databaseConfig: DatabaseConfig[P], slickSettings: SlickSettings) =
+  def this(system: ActorSystem[?], databaseConfig: DatabaseConfig[P], slickSettings: SlickSettings) =
     this(system, databaseConfig, slickSettings, Clock.systemUTC())
 
   private[projection] val profile: P = databaseConfig.profile
@@ -94,17 +94,17 @@ import slick.jdbc.JdbcProfile
     results.map {
       case Nil                              => None
       case reps if reps.forall(_.mergeable) =>
-        Some(fromStorageRepresentation[MergeableOffset[_], Offset](MultipleOffsets(reps.toList)).asInstanceOf[Offset])
+        Some(fromStorageRepresentation[MergeableOffset[?], Offset](MultipleOffsets(reps.toList)).asInstanceOf[Offset])
       case reps =>
         reps.find(_.id == projectionId).map(fromStorageRepresentation[Offset, Offset])
     }
   }
 
-  private def newRow[Offset](rep: SingleOffset, millisSinceEpoch: Long): DBIO[_] =
+  private def newRow[Offset](rep: SingleOffset, millisSinceEpoch: Long): DBIO[?] =
     offsetTable.insertOrUpdate(
       OffsetRow(rep.id.name, rep.id.key, rep.offsetStr, rep.manifest, rep.mergeable, millisSinceEpoch))
 
-  def saveOffset[Offset](projectionId: ProjectionId, offset: Offset): slick.dbio.DBIO[_] = {
+  def saveOffset[Offset](projectionId: ProjectionId, offset: Offset): slick.dbio.DBIO[?] = {
     val millisSinceEpoch = clock.instant().toEpochMilli
     toStorageRepresentation(projectionId, offset) match {
       case offset: SingleOffset  => newRow(offset, millisSinceEpoch)
@@ -114,7 +114,7 @@ import slick.jdbc.JdbcProfile
     }
   }
 
-  def clearOffset(projectionId: ProjectionId): slick.dbio.DBIO[_] = {
+  def clearOffset(projectionId: ProjectionId): slick.dbio.DBIO[?] = {
     offsetTable.filter(row => row.projectionName === projectionId.name && row.projectionKey === projectionId.key).delete
   }
 

--- a/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickProjectionImpl.scala
+++ b/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickProjectionImpl.scala
@@ -93,7 +93,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
   /*
    * Build the final ProjectionSettings to use, if currently set to None fallback to values in config file
    */
-  private def settingsOrDefaults(implicit system: ActorSystem[_]): ProjectionSettings = {
+  private def settingsOrDefaults(implicit system: ActorSystem[?]): ProjectionSettings = {
     val settings = settingsOpt.getOrElse(ProjectionSettings(system))
     restartBackoffOpt match {
       case None    => settings
@@ -160,7 +160,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
    * Return a RunningProjection
    */
   @InternalApi
-  override private[projection] def run()(implicit system: ActorSystem[_]): RunningProjection = {
+  override private[projection] def run()(implicit system: ActorSystem[?]): RunningProjection = {
     new SlickInternalProjectionState(settingsOrDefaults).newRunningInstance()
   }
 
@@ -170,7 +170,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
    * This method returns the projection Source mapped with user 'handler' function, but before any sink attached.
    * This is mainly intended to be used by the TestKit allowing it to attach a TestSink to it.
    */
-  override private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
+  override private[projection] def mappedSource()(implicit system: ActorSystem[?]): Source[Done, Future[Done]] =
     new SlickInternalProjectionState(settingsOrDefaults).mappedSource()
 
   /*
@@ -178,7 +178,7 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
    * This internal class will hold the KillSwitch that is needed
    * when building the mappedSource and when running the projection (to stop)
    */
-  private class SlickInternalProjectionState(settings: ProjectionSettings)(implicit val system: ActorSystem[_])
+  private class SlickInternalProjectionState(settings: ProjectionSettings)(implicit val system: ActorSystem[?])
       extends InternalProjectionState[Offset, Envelope](
         projectionId,
         sourceProvider,
@@ -204,8 +204,8 @@ private[projection] class SlickProjectionImpl[Offset, Envelope, P <: JdbcProfile
 
   }
 
-  private class SlickRunningProjection(source: Source[Done, _], projectionState: SlickInternalProjectionState)(
-      implicit system: ActorSystem[_])
+  private class SlickRunningProjection(source: Source[Done, ?], projectionState: SlickInternalProjectionState)(
+      implicit system: ActorSystem[?])
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 

--- a/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickSettings.scala
+++ b/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickSettings.scala
@@ -43,7 +43,7 @@ private[projection] object SlickSettings {
 
   val configPath = "pekko.projection.slick"
 
-  def apply(system: ActorSystem[_]): SlickSettings =
+  def apply(system: ActorSystem[?]): SlickSettings =
     SlickSettings(system.settings.config.getConfig(configPath))
 
 }

--- a/slick/src/test/scala/org/apache/pekko/projection/slick/SlickProjectionSpec.scala
+++ b/slick/src/test/scala/org/apache/pekko/projection/slick/SlickProjectionSpec.scala
@@ -198,7 +198,7 @@ class SlickProjectionSpec
 
   private def genRandomProjectionId() = ProjectionId(UUID.randomUUID().toString, "00")
 
-  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[_]): Throwable = {
+  @tailrec private def eventuallyExpectError(sinkProbe: TestSubscriber.Probe[?]): Throwable = {
     sinkProbe.expectNextOrError() match {
       case Right(_)  => eventuallyExpectError(sinkProbe)
       case Left(exc) => exc

--- a/testkit/src/main/scala/org/apache/pekko/projection/testkit/internal/TestProjectionImpl.scala
+++ b/testkit/src/main/scala/org/apache/pekko/projection/testkit/internal/TestProjectionImpl.scala
@@ -116,7 +116,7 @@ private[projection] class TestProjectionImpl[Offset, Envelope] private[projectio
    * INTERNAL API: To control the [[pekko.projection.internal.InternalProjectionState]] used in the projection.
    */
   @InternalApi
-  private[projection] def newState(implicit system: ActorSystem[_]): TestInternalProjectionState[Offset, Envelope] =
+  private[projection] def newState(implicit system: ActorSystem[?]): TestInternalProjectionState[Offset, Envelope] =
     new TestInternalProjectionState(
       projectionId,
       sourceProvider,
@@ -126,18 +126,18 @@ private[projection] class TestProjectionImpl[Offset, Envelope] private[projectio
       offsetStoreFactory(),
       startOffset)
 
-  private def state(implicit system: ActorSystem[_]): TestInternalProjectionState[Offset, Envelope] = {
+  private def state(implicit system: ActorSystem[?]): TestInternalProjectionState[Offset, Envelope] = {
     if (_state.isEmpty) _state = Some(newState)
     _state.get
   }
 
-  override def run()(implicit system: ActorSystem[_]): RunningProjection = state.newRunningInstance()
+  override def run()(implicit system: ActorSystem[?]): RunningProjection = state.newRunningInstance()
 
   /**
    * INTERNAL API
    */
   @InternalApi
-  private[projection] def mappedSource()(implicit system: ActorSystem[_]): Source[Done, Future[Done]] =
+  private[projection] def mappedSource()(implicit system: ActorSystem[?]): Source[Done, Future[Done]] =
     state.mappedSource()
 }
 
@@ -154,7 +154,7 @@ private[projection] class TestInternalProjectionState[Offset, Envelope](
     offsetStrategy: OffsetStrategy,
     statusObserver: StatusObserver[Envelope],
     offsetStore: TestOffsetStore[Offset],
-    startOffset: Option[Offset])(implicit val system: ActorSystem[_])
+    startOffset: Option[Offset])(implicit val system: ActorSystem[?])
     extends InternalProjectionState[Offset, Envelope](
       projectionId,
       sourceProvider,
@@ -187,8 +187,8 @@ private[projection] class TestInternalProjectionState[Offset, Envelope](
  * INTERNAL API
  */
 @InternalApi
-private[projection] class TestRunningProjection(val source: Source[Done, _], killSwitch: SharedKillSwitch)(
-    implicit val system: ActorSystem[_])
+private[projection] class TestRunningProjection(val source: Source[Done, ?], killSwitch: SharedKillSwitch)(
+    implicit val system: ActorSystem[?])
     extends RunningProjection {
 
   protected val futureDone: Future[Done] = run()

--- a/testkit/src/main/scala/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKit.scala
@@ -29,12 +29,12 @@ import scala.jdk.DurationConverters._
 
 @ApiMayChange
 object ProjectionTestKit {
-  def create(system: ActorSystem[_]): ProjectionTestKit =
+  def create(system: ActorSystem[?]): ProjectionTestKit =
     new ProjectionTestKit(system)
 }
 
 @ApiMayChange
-final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
+final class ProjectionTestKit private[projection] (system: ActorSystem[?]) {
   private val delegate = scaladsl.ProjectionTestKit(system)
 
   /**
@@ -51,7 +51,7 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param projection - the Projection to run
    * @param assertFunction - a function that exercises the test assertions
    */
-  def run(projection: Projection[_], assertFunction: Effect): Unit =
+  def run(projection: Projection[?], assertFunction: Effect): Unit =
     delegate.run(projection)(assertFunction.apply())
 
   /**
@@ -69,7 +69,7 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param max - Duration delimiting the max duration of the test
    * @param assertFunction - a function that exercises the test assertions
    */
-  def run(projection: Projection[_], max: Duration, assertFunction: Effect): Unit =
+  def run(projection: Projection[?], max: Duration, assertFunction: Effect): Unit =
     delegate.run(projection, max.toScala)(assertFunction.apply())
 
   /**
@@ -89,7 +89,7 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param interval - Duration defining the interval in each the assert function will be called
    * @param assertFunction - a function that exercises the test assertions
    */
-  def run(projection: Projection[_], max: Duration, interval: Duration, assertFunction: Effect): Unit =
+  def run(projection: Projection[?], max: Duration, interval: Duration, assertFunction: Effect): Unit =
     delegate.run(projection, max.toScala, interval.toScala)(assertFunction.apply())
 
   /**
@@ -105,7 +105,7 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param projection - the Projection to run
    * @param assertFunction - a function receiving a `TestSubscriber.Probe[Done]`
    */
-  def runWithTestSink(projection: Projection[_], assertFunction: Procedure[TestSubscriber.Probe[Done]]): Unit =
+  def runWithTestSink(projection: Projection[?], assertFunction: Procedure[TestSubscriber.Probe[Done]]): Unit =
     delegate.runWithTestSink(projection)(probe => assertFunction.apply(probe))
 
 }

--- a/testkit/src/main/scala/org/apache/pekko/projection/testkit/scaladsl/ProjectionTestKit.scala
+++ b/testkit/src/main/scala/org/apache/pekko/projection/testkit/scaladsl/ProjectionTestKit.scala
@@ -30,12 +30,12 @@ import pekko.stream.testkit.scaladsl.TestSink
 
 @ApiMayChange
 object ProjectionTestKit {
-  def apply(system: ActorSystem[_]): ProjectionTestKit =
+  def apply(system: ActorSystem[?]): ProjectionTestKit =
     new ProjectionTestKit(system)
 }
 
 @ApiMayChange
-final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
+final class ProjectionTestKit private[projection] (system: ActorSystem[?]) {
 
   private val testKit = ActorTestKit(system)
 
@@ -54,7 +54,7 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param projection - the Projection to run
    * @param assertFunction - a by-name code block that exercise the test assertions
    */
-  def run(projection: Projection[_])(assertFunction: => Unit): Unit =
+  def run(projection: Projection[?])(assertFunction: => Unit): Unit =
     runInternal(projection, assertFunction, testKit.testKitSettings.SingleExpectDefaultTimeout, 100.millis)
 
   /**
@@ -72,7 +72,7 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param max - FiniteDuration delimiting the max duration of the test
    * @param assertFunction - a by-name code block that exercise the test assertions
    */
-  def run(projection: Projection[_], max: FiniteDuration)(assertFunction: => Unit): Unit =
+  def run(projection: Projection[?], max: FiniteDuration)(assertFunction: => Unit): Unit =
     runInternal(projection, assertFunction, max, 100.millis)
 
   /**
@@ -92,11 +92,11 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param interval - FiniteDuration defining the interval in each the assert function will be called
    * @param assertFunction - a by-name code block that exercise the test assertions
    */
-  def run(projection: Projection[_], max: FiniteDuration, interval: FiniteDuration)(assertFunction: => Unit): Unit =
+  def run(projection: Projection[?], max: FiniteDuration, interval: FiniteDuration)(assertFunction: => Unit): Unit =
     runInternal(projection, assertFunction, max, interval)
 
   private def runInternal(
-      projection: Projection[_],
+      projection: Projection[?],
       assertFunction: => Unit,
       max: FiniteDuration,
       interval: FiniteDuration): Unit = {
@@ -128,9 +128,9 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
    * @param projection - the Projection to run
    * @param assertFunction - a function receiving a `TestSubscriber.Probe[Done]`
    */
-  def runWithTestSink(projection: Projection[_])(assertFunction: TestSubscriber.Probe[Done] => Unit): Unit = {
+  def runWithTestSink(projection: Projection[?])(assertFunction: TestSubscriber.Probe[Done] => Unit): Unit = {
     val actorHandler = spawnActorHandler(projection)
-    implicit val sys: ActorSystem[_] = system
+    implicit val sys: ActorSystem[?] = system
     val sinkProbe = projection.mappedSource().runWith(TestSink[Done]()(testKit.system.classicSystem))
     try {
       assertFunction(sinkProbe)
@@ -140,7 +140,7 @@ final class ProjectionTestKit private[projection] (system: ActorSystem[_]) {
     }
   }
 
-  private def spawnActorHandler(projection: Projection[_]): Option[ActorRef[_]] = {
+  private def spawnActorHandler(projection: Projection[?]): Option[ActorRef[?]] = {
     projection.actorHandlerInit[Any].map { init =>
       val ref = testKit.spawn(Behaviors.supervise(init.behavior).onFailure(SupervisorStrategy.restart))
       init.setActor(ref)

--- a/testkit/src/test/scala/org/apache/pekko/projection/testkit/scaladsl/TestProjectionSpec.scala
+++ b/testkit/src/test/scala/org/apache/pekko/projection/testkit/scaladsl/TestProjectionSpec.scala
@@ -42,7 +42,7 @@ object TestProjectionSpec {
       appender(strBuffer)
   }
 
-  class AppenderActorHandler(behavior: Behavior[Command])(implicit system: ActorSystem[_])
+  class AppenderActorHandler(behavior: Behavior[Command])(implicit system: ActorSystem[?])
       extends ActorHandler[Int, Command](behavior) {
     import pekko.actor.typed.scaladsl.AskPattern._
 


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-projection.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048