### PR TITLE
chore: unify formatter config - standardize aliases, add JDK17 setting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ jobs:
         uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v8.1.1
 
       - name: Code style check and binary-compatibility check
-        run: sbt "verifyCodeStyle; mimaReportBinaryIssues"
+        run: sbt "checkCodeStyle; mimaReportBinaryIssues"
 
   check-code-compilation:
     name: Check Code Compilation

--- a/build.sbt
+++ b/build.sbt
@@ -351,11 +351,5 @@ lazy val root = Project(id = "projection", base = file("."))
   .disablePlugins(SitePlugin, MimaPlugin)
 
 // check format and headers
-TaskKey[Unit]("verifyCodeFmt") := {
-  javafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
-    throw new MessageOnlyException(
-      "Unformatted Java code found. Please run 'javafmtAll' and commit the reformatted code")
-  }
-}
-
-addCommandAlias("verifyCodeStyle", "headerCheckAll; verifyCodeFmt")
+addCommandAlias("checkCodeStyle", "scalafmtCheckAll; scalafmtSbtCheck; javafmtCheckAll; +headerCheckAll")
+addCommandAlias("applyCodeStyle", "+headerCreateAll; scalafmtAll; scalafmtSbt; javafmtAll")


### PR DESCRIPTION
### Motivation
Align formatter plugins, command aliases, and JDK settings with other pekko sub-projects to reduce maintenance burden and ensure consistent formatting configuration across the ecosystem.

### Modification
- Standardize `checkCodeStyle`/`applyCodeStyle` command aliases
- Add `ThisBuild / javafmtFormatterCompatibleJavaVersion := 17` where missing
- Replace custom `verifyCodeFmt` tasks with standard aliases where applicable
- Upgrade sbt-java-formatter plugin where needed

### Result
Consistent formatter configuration across all pekko sub-projects, enabling unified `sbt checkCodeStyle` / `sbt applyCodeStyle` workflow.

### Tests
Not run - build config change only

### References
None - formatter unification across pekko sub-projects