### PR TITLE
fix: Scala 3.8+ forward compatibility

### DIFF
--- a/core/src/main/scala/org/apache/pekko/projection/javadsl/StatefulHandler.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/javadsl/StatefulHandler.scala
@@ -21,7 +21,7 @@ import pekko.annotation.ApiMayChange
 
 @ApiMayChange abstract class StatefulHandler[State, Envelope] extends Handler[Envelope] {
 
-  private var state: CompletionStage[State] = _
+  private var state: CompletionStage[State] = null
 
   /**
    * Invoked to load the initial state when the projection is started or if previous `process` failed.

--- a/core/src/main/scala/org/apache/pekko/projection/scaladsl/StatefulHandler.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/scaladsl/StatefulHandler.scala
@@ -24,7 +24,7 @@ import pekko.annotation.ApiMayChange
 
 @ApiMayChange abstract class StatefulHandler[State, Envelope](implicit ec: ExecutionContext) extends Handler[Envelope] {
 
-  private var state: Future[State] = _
+  private var state: Future[State] = null
 
   /**
    * Invoked to load the initial state when the projection is started or if previous `process` failed.

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/FilterStage.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/FilterStage.scala
@@ -161,7 +161,7 @@ import org.slf4j.LoggerFactory
   override def createLogic(inheritedAttributes: Attributes): GraphStageLogic =
     new GraphStageLogic(shape) {
 
-      private var persistence: Persistence = _
+      private var persistence: Persistence = null
 
       // only one pull replay stream -> async callback at a time
       private var replayHasBeenPulled = false

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -45,7 +45,20 @@ object PekkoDisciplinePlugin extends AutoPlugin {
                 // scala/bug#7014 is a false positive compiler warning affecting r2dbc-spi jar loading
                 "-Wconf:msg=scala/bug#7014:s")
             case Some((3, _)) =>
-              Set("-Yfuture-lazy-vals", "-release:17")
+              Set(
+                "-Yfuture-lazy-vals",
+                "-release:17",
+                "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+                "-Wconf:msg=is deprecated for wildcard arguments of types:s",
+                "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
+                "-Wconf:msg=with as a type operator has been deprecated:s",
+                "-Wconf:msg=Unreachable case except for null:s",
+                "-Wconf:msg=is no longer supported for vararg splices:s",
+                "-Wconf:msg=is not declared infix:s",
+                "-Wconf:msg=Xfatal-warnings is a deprecated alias:s",
+                "-Wconf:msg=Ignoring \\[this\\] qualifier:s",
+                "-Wconf:msg=trait App in package scala is deprecated:s",
+                "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
             case _ =>
               Nil
           }).toSeq,

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -162,7 +162,7 @@ final class R2dbcProjectionSettings private (
     MurmurHash3.finalizeHash(h, values.size)
   }
 
-  private[this] def copy(
+  private def copy(
       dialect: Dialect = dialect,
       schema: Option[String] = schema,
       offsetTable: String = offsetTable,


### PR DESCRIPTION
## Summary
- Replace `= _` with explicit `= null` in var declarations (deprecated in Scala 3.8)
- Replace `private[this]` with `private` (deprecated in Scala 3.8)
- Add `-Wconf` suppressions for cross-version incompatible warnings in Scala 3 compiler options

## Details
This PR prepares pekko-projection for Scala 3.8/3.9 adoption while maintaining compatibility with current Scala 3.3.x and 2.13.x production builds.

### Code changes (3 files)
- `core/.../javadsl/StatefulHandler.scala`: `var state = _` → `= null`
- `core/.../scaladsl/StatefulHandler.scala`: `var state = _` → `= null`
- `grpc/.../FilterStage.scala`: `var persistence = _` → `= null`
- `r2dbc/.../R2dbcProjectionSettings.scala`: `private[this]` → `private`

### Compiler options (`project/PekkoDisciplinePlugin.scala`)
Added `-Wconf` suppressions for Scala 3 warnings that are not actionable on current versions:
- Context bounds `using` clause syntax
- Wildcard type arguments
- Eta-expansion trailing `_`
- `with` as type operator
- Unreachable null cases
- Vararg splice syntax
- Infix type declarations
- `-Xfatal-warnings` deprecation alias
- Generated gRPC code `private[this]`
- `trait App` deprecation
- `-Yfuture-lazy-vals` bad option on 3.8+

Verified: clean compilation on Scala 3.8.4 with zero warnings (main + test sources).

## Test plan
- [x] `sbt "++3.8.4; clean; compile; Test/compile"` — zero warnings
- [ ] CI passes on current Scala 3.3.x and 2.13.x
- [ ] No binary compatibility issues