### PR TITLE
build: fix sbt lint warnings by excluding unused mimaPreviousArtifacts key

### DIFF
--- a/project/Common.scala
+++ b/project/Common.scala
@@ -37,7 +37,8 @@ object Common extends AutoPlugin {
         "Contributors",
         "dev@pekko.apache.org",
         url("https://github.com/apache/pekko-projection/graphs/contributors")),
-      description := "Apache Pekko Projection.")
+      description := "Apache Pekko Projection.",
+      excludeLintKeys ++= Set(mimaPreviousArtifacts))
 
   val mimaCompareVersion = "1.0.0"
 


### PR DESCRIPTION
### Motivation
sbt lint reported 15 unused `mimaPreviousArtifacts` keys across sub-projects (bill-of-materials, cassandra-test, core-test, docs, examples, grpc, grpc-int-test, grpc-test, integration-examples, jdbc-int-test, kafka-test, projection, r2dbc-int-test, slick-int-test).

### Modification
Add `mimaPreviousArtifacts` to `Global / excludeLintKeys` in `project/Common.scala`.

### Result
sbt load no longer reports unused `mimaPreviousArtifacts` keys.

### Tests
- `sbt "clean; compile"` - all mimaPreviousArtifacts lint warnings resolved

### References
None - build configuration cleanup