### PR TITLE
fix: Scala 3.9 compatibility fixes

### DIFF
--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -57,7 +57,9 @@ object PekkoDisciplinePlugin extends AutoPlugin {
                 "-Wconf:msg=Xfatal-warnings is a deprecated alias:s",
                 "-Wconf:msg=Ignoring \\[this\\] qualifier:s",
                 "-Wconf:msg=trait App in package scala is deprecated:s") ++
-              (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
+              (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
+                 Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+               else Seq.empty)
             case _ =>
               Nil
           }).toSeq,

--- a/project/PekkoDisciplinePlugin.scala
+++ b/project/PekkoDisciplinePlugin.scala
@@ -46,7 +46,6 @@ object PekkoDisciplinePlugin extends AutoPlugin {
                 "-Wconf:msg=scala/bug#7014:s")
             case Some((3, _)) =>
               Set(
-                "-Yfuture-lazy-vals",
                 "-release:17",
                 "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
                 "-Wconf:msg=is deprecated for wildcard arguments of types:s",
@@ -57,8 +56,8 @@ object PekkoDisciplinePlugin extends AutoPlugin {
                 "-Wconf:msg=is not declared infix:s",
                 "-Wconf:msg=Xfatal-warnings is a deprecated alias:s",
                 "-Wconf:msg=Ignoring \\[this\\] qualifier:s",
-                "-Wconf:msg=trait App in package scala is deprecated:s",
-                "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+                "-Wconf:msg=trait App in package scala is deprecated:s") ++
+              (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
             case _ =>
               Nil
           }).toSeq,

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -32,7 +32,7 @@ object R2dbcProjectionSettings {
   def apply(config: Config): R2dbcProjectionSettings = {
     val logDbCallsExceeding: FiniteDuration =
       config.getString("log-db-calls-exceeding").toLowerCase(Locale.ROOT) match {
-        case "off" => -1.millis
+        case "off" => (-1).millis
         case _     => config.getDuration("log-db-calls-exceeding").toScala
       }
 

--- a/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickOffsetStore.scala
+++ b/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickOffsetStore.scala
@@ -25,7 +25,6 @@ import pekko.projection.MergeableOffset
 import pekko.projection.ProjectionId
 import pekko.projection.internal.ManagementState
 import pekko.projection.internal.OffsetSerialization
-import pekko.projection.jdbc.internal.Dialect
 import pekko.projection.jdbc.internal.H2Dialect
 import pekko.projection.jdbc.internal.JdbcSessionUtil
 import pekko.projection.jdbc.internal.MSSQLServerDialect

--- a/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickOffsetStore.scala
+++ b/slick/src/main/scala/org/apache/pekko/projection/slick/internal/SlickOffsetStore.scala
@@ -54,7 +54,7 @@ import slick.jdbc.JdbcProfile
   import OffsetSerialization.MultipleOffsets
   import OffsetSerialization.SingleOffset
 
-  val (dialect, useLowerCase): (Dialect, Boolean) = {
+  val (dialect, useLowerCase) = {
 
     val useLowerCase = slickSettings.useLowerCase
 


### PR DESCRIPTION
### Motivation
Scala 3.9.0-RC1 introduces stricter rules that cause compilation failures under `-Werror`:
1. Type ascriptions after tuple destructuring patterns are no longer supported
2. Negative literals like `-1.millis` are flagged as "Illegal literal"

### Modification
- `SlickOffsetStore.scala`: Remove type ascription `(Dialect, Boolean)` from tuple destructuring pattern
- `R2dbcProjectionSettings.scala`: Parenthesize negative literal `-1.millis` → `(-1).millis`

### Result
pekko-projection compiles cleanly with Scala 3.9.0-RC1.

### Tests
- `sbt "++3.9.0-RC1!; compile; Test/compile"` passes

### References
None - Scala 3.9 forward compatibility