### PR TITLE
refactor: modernize Java test and example code with Java 17 features

### DIFF
--- a/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
+++ b/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
@@ -95,17 +95,7 @@ public class CassandraProjectionTest extends JUnitSuite {
         .get(10, TimeUnit.SECONDS);
   }
 
-  static class Envelope {
-    final String id;
-    final long offset;
-    final String message;
-
-    Envelope(String id, long offset, String message) {
-      this.id = id;
-      this.offset = offset;
-      this.message = message;
-    }
-  }
+  record Envelope(String id, long offset, String message) {}
 
   public static SourceProvider<Long, Envelope> sourceProvider(String entityId) {
     Source<Envelope, NotUsed> envelopes =
@@ -119,7 +109,7 @@ public class CassandraProjectionTest extends JUnitSuite {
                 new Envelope(entityId, 6, "pqr")));
 
     TestSourceProvider<Long, Envelope> sourceProvider =
-        TestSourceProvider.create(envelopes, env -> env.offset)
+        TestSourceProvider.create(envelopes, env -> env.offset())
             .withStartSourceFrom(
                 (Long lastProcessedOffset, Long offset) -> offset <= lastProcessedOffset);
 
@@ -147,23 +137,15 @@ public class CassandraProjectionTest extends JUnitSuite {
   }
 
   static class TestHandlerBehavior {
-    static class Req {
-      public final Envelope envelope;
-      public final ActorRef<Done> replyTo;
-
-      Req(Envelope envelope, ActorRef<Done> replyTo) {
-        this.envelope = envelope;
-        this.replyTo = replyTo;
-      }
-    }
+    record Req(Envelope envelope, ActorRef<Done> replyTo) {}
 
     static Behavior<Req> create(ActorRef<Envelope> receiveProbe, ActorRef<Done> stopProbe) {
       return Behaviors.receive(Req.class)
           .onMessage(
               Req.class,
               req -> {
-                receiveProbe.tell(req.envelope);
-                req.replyTo.tell(Done.getInstance());
+                receiveProbe.tell(req.envelope());
+                req.replyTo().tell(Done.getInstance());
                 return Behaviors.same();
               })
           .onSignal(
@@ -205,7 +187,7 @@ public class CassandraProjectionTest extends JUnitSuite {
   private Handler<Envelope> concatHandler(StringBuffer str) {
     return Handler.fromFunction(
         envelope -> {
-          str.append(envelope.message).append("|");
+          str.append(envelope.message()).append("|");
           return CompletableFuture.completedFuture(Done.getInstance());
         });
   }
@@ -213,8 +195,8 @@ public class CassandraProjectionTest extends JUnitSuite {
   private Handler<Envelope> concatHandlerFail4(StringBuffer str) {
     return Handler.fromFunction(
         envelope -> {
-          if (envelope.offset == 4) throw new RuntimeException("fail on 4");
-          str.append(envelope.message).append("|");
+          if (envelope.offset() == 4) throw new RuntimeException("fail on 4");
+          str.append(envelope.message()).append("|");
           return CompletableFuture.completedFuture(Done.getInstance());
         });
   }
@@ -234,7 +216,7 @@ public class CassandraProjectionTest extends JUnitSuite {
     public CompletionStage<Done> process(List<Envelope> envelopes) {
       handlerProbe.ref().tell(GroupedConcatHandler.handlerCalled);
       for (Envelope env : envelopes) {
-        str.append(env.message).append("|");
+        str.append(env.message()).append("|");
       }
       return CompletableFuture.completedFuture(Done.getInstance());
     }
@@ -402,12 +384,12 @@ public class CassandraProjectionTest extends JUnitSuite {
     ActorRef<ProjectionBehavior.Command> projectionRef =
         testKit.spawn(ProjectionBehavior.create(projection));
 
-    assertEquals("abc", receiveProbe.receiveMessage().message);
-    assertEquals("def", receiveProbe.receiveMessage().message);
-    assertEquals("ghi", receiveProbe.receiveMessage().message);
-    assertEquals("jkl", receiveProbe.receiveMessage().message);
-    assertEquals("mno", receiveProbe.receiveMessage().message);
-    assertEquals("pqr", receiveProbe.receiveMessage().message);
+    assertEquals("abc", receiveProbe.receiveMessage().message());
+    assertEquals("def", receiveProbe.receiveMessage().message());
+    assertEquals("ghi", receiveProbe.receiveMessage().message());
+    assertEquals("jkl", receiveProbe.receiveMessage().message());
+    assertEquals("mno", receiveProbe.receiveMessage().message());
+    assertEquals("pqr", receiveProbe.receiveMessage().message());
 
     projectionRef.tell(ProjectionBehavior.stopMessage());
 

--- a/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
+++ b/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
@@ -128,7 +128,8 @@ public class ShoppingCart
   public record Checkout(ActorRef<Confirmation> replyTo) implements Command {}
 
   /** Summary of the shopping cart state, used in reply messages. */
-  public record Summary(Map<String, Integer> items, boolean checkedOut) implements CborSerializable {
+  public record Summary(Map<String, Integer> items, boolean checkedOut)
+      implements CborSerializable {
     public Summary {
       items = Collections.unmodifiableMap(new HashMap<>(items));
     }
@@ -258,7 +259,8 @@ public class ShoppingCart
         return Effect()
             .reply(
                 cmd.replyTo(),
-                new Rejected("Item '" + cmd.itemId() + "' was already added to this shopping cart"));
+                new Rejected(
+                    "Item '" + cmd.itemId() + "' was already added to this shopping cart"));
       } else if (cmd.quantity() <= 0) {
         return Effect().reply(cmd.replyTo(), new Rejected("Quantity must be greater than zero"));
       } else {
@@ -298,7 +300,8 @@ public class ShoppingCart
 
     public ReplyEffect<Event, State> onCheckout(State state, Checkout cmd) {
       if (state.isEmpty()) {
-        return Effect().reply(cmd.replyTo(), new Rejected("Cannot checkout an empty shopping cart"));
+        return Effect()
+            .reply(cmd.replyTo(), new Rejected("Cannot checkout an empty shopping cart"));
       } else {
         return Effect()
             .persist(new CheckedOut(cartId, Instant.now()))
@@ -339,7 +342,8 @@ public class ShoppingCart
   public EventHandler<State, Event> eventHandler() {
     return newEventHandlerBuilder()
         .forAnyState()
-        .onEvent(ItemAdded.class, (state, event) -> state.updateItem(event.itemId(), event.quantity()))
+        .onEvent(
+            ItemAdded.class, (state, event) -> state.updateItem(event.itemId(), event.quantity()))
         .onEvent(ItemRemoved.class, (state, event) -> state.removeItem(event.itemId()))
         .onEvent(
             ItemQuantityAdjusted.class,

--- a/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
+++ b/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
@@ -13,7 +13,6 @@
 
 package jdocs.eventsourced;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
@@ -103,56 +102,22 @@ public class ShoppingCart
    * <p>It can reply with `Confirmation`, which is sent back to the caller when all the events
    * emitted by this command are successfully persisted.
    */
-  public static class AddItem implements Command {
-    public final String itemId;
-    public final int quantity;
-    public final ActorRef<Confirmation> replyTo;
+  public record AddItem(String itemId, int quantity, ActorRef<Confirmation> replyTo)
+      implements Command {}
 
-    public AddItem(String itemId, int quantity, ActorRef<Confirmation> replyTo) {
-      this.itemId = itemId;
-      this.quantity = quantity;
-      this.replyTo = replyTo;
-    }
-  }
-
-  /** A command to remove an item from the cart. */
-  public static class RemoveItem implements Command {
-    public final String itemId;
-    public final ActorRef<Confirmation> replyTo;
-
-    @JsonCreator
-    public RemoveItem(String itemId, ActorRef<Confirmation> replyTo) {
-      this.itemId = itemId;
-      this.replyTo = replyTo;
-    }
-  }
+  /** A command to remove an item in the cart. */
+  public record RemoveItem(String itemId, ActorRef<Confirmation> replyTo) implements Command {}
 
   /** A command to adjust the quantity of an item in the cart. */
-  public static class AdjustItemQuantity implements Command {
-    public final String itemId;
-    public final int quantity;
-    public final ActorRef<Confirmation> replyTo;
-
-    public AdjustItemQuantity(String itemId, int quantity, ActorRef<Confirmation> replyTo) {
-      this.itemId = itemId;
-      this.quantity = quantity;
-      this.replyTo = replyTo;
-    }
-  }
+  public record AdjustItemQuantity(String itemId, int quantity, ActorRef<Confirmation> replyTo)
+      implements Command {}
 
   /**
    * A command to get the current state of the shopping cart.
    *
    * <p>The reply type is the {@link Summary}
    */
-  public static class Get implements Command {
-    public final ActorRef<Summary> replyTo;
-
-    @JsonCreator
-    public Get(ActorRef<Summary> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
+  public record Get(ActorRef<Summary> replyTo) implements Command {}
 
   /**
    * A command to checkout the shopping cart.
@@ -160,125 +125,47 @@ public class ShoppingCart
    * <p>The reply type is the {@link Confirmation}, which will be returned when the events have been
    * emitted.
    */
-  public static class Checkout implements Command {
-    public final ActorRef<Confirmation> replyTo;
-
-    @JsonCreator
-    public Checkout(ActorRef<Confirmation> replyTo) {
-      this.replyTo = replyTo;
-    }
-  }
+  public record Checkout(ActorRef<Confirmation> replyTo) implements Command {}
 
   /** Summary of the shopping cart state, used in reply messages. */
-  public static final class Summary implements CborSerializable {
-    public final Map<String, Integer> items;
-    public final boolean checkedOut;
-
-    public Summary(Map<String, Integer> items, boolean checkedOut) {
-      // Summary is included in messages and should therefore be immutable
-      this.items = Collections.unmodifiableMap(new HashMap<>(items));
-      this.checkedOut = checkedOut;
+  public record Summary(Map<String, Integer> items, boolean checkedOut) implements CborSerializable {
+    public Summary {
+      items = Collections.unmodifiableMap(new HashMap<>(items));
     }
   }
 
   public interface Confirmation extends CborSerializable {}
 
-  public static class Accepted implements Confirmation {
-    public final Summary summary;
+  public record Accepted(Summary summary) implements Confirmation {}
 
-    @JsonCreator
-    public Accepted(Summary summary) {
-      this.summary = summary;
-    }
-  }
-
-  public static class Rejected implements Confirmation {
-    public final String reason;
-
-    public Rejected(String reason) {
-      this.reason = reason;
-    }
-  }
+  public record Rejected(String reason) implements Confirmation {}
 
   public interface Event extends CborSerializable {
-    public String getCartId();
+    String cartId();
   }
 
-  public static final class ItemAdded implements Event {
-    public final String cartId;
-    public final String itemId;
-    public final int quantity;
-
-    public ItemAdded(String cartId, String itemId, int quantity) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-      this.quantity = quantity;
-    }
-
-    public String getCartId() {
-      return cartId;
-    }
-
+  public record ItemAdded(String cartId, String itemId, int quantity) implements Event {
     @Override
     public String toString() {
       return "ItemAdded(" + cartId + "," + itemId + "," + quantity + ")";
     }
   }
 
-  public static final class ItemRemoved implements Event {
-    public final String cartId;
-    public final String itemId;
-
-    public ItemRemoved(String cartId, String itemId) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-    }
-
-    public String getCartId() {
-      return cartId;
-    }
-
+  public record ItemRemoved(String cartId, String itemId) implements Event {
     @Override
     public String toString() {
       return "ItemRemoved(" + cartId + "," + itemId + ")";
     }
   }
 
-  public static final class ItemQuantityAdjusted implements Event {
-    public final String cartId;
-    public final String itemId;
-    public final int quantity;
-
-    public ItemQuantityAdjusted(String cartId, String itemId, int quantity) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-      this.quantity = quantity;
-    }
-
-    public String getCartId() {
-      return cartId;
-    }
-
+  public record ItemQuantityAdjusted(String cartId, String itemId, int quantity) implements Event {
     @Override
     public String toString() {
       return "ItemQuantityAdjusted(" + cartId + "," + itemId + "," + quantity + ")";
     }
   }
 
-  public static class CheckedOut implements Event {
-
-    public final String cartId;
-    public final Instant eventTime;
-
-    public CheckedOut(String cartId, Instant eventTime) {
-      this.cartId = cartId;
-      this.eventTime = eventTime;
-    }
-
-    public String getCartId() {
-      return cartId;
-    }
-
+  public record CheckedOut(String cartId, Instant eventTime) implements Event {
     @Override
     public String toString() {
       return "CheckedOut(" + cartId + "," + eventTime + ")";
@@ -361,61 +248,61 @@ public class ShoppingCart
   }
 
   private ReplyEffect<Event, State> onGet(State state, Get cmd) {
-    return Effect().reply(cmd.replyTo, state.toSummary());
+    return Effect().reply(cmd.replyTo(), state.toSummary());
   }
 
   private class OpenShoppingCartCommandHandlers {
 
     public ReplyEffect<Event, State> onAddItem(State state, AddItem cmd) {
-      if (state.hasItem(cmd.itemId)) {
+      if (state.hasItem(cmd.itemId())) {
         return Effect()
             .reply(
-                cmd.replyTo,
-                new Rejected("Item '" + cmd.itemId + "' was already added to this shopping cart"));
-      } else if (cmd.quantity <= 0) {
-        return Effect().reply(cmd.replyTo, new Rejected("Quantity must be greater than zero"));
+                cmd.replyTo(),
+                new Rejected("Item '" + cmd.itemId() + "' was already added to this shopping cart"));
+      } else if (cmd.quantity() <= 0) {
+        return Effect().reply(cmd.replyTo(), new Rejected("Quantity must be greater than zero"));
       } else {
         return Effect()
-            .persist(new ItemAdded(cartId, cmd.itemId, cmd.quantity))
-            .thenReply(cmd.replyTo, updatedCart -> new Accepted(updatedCart.toSummary()));
+            .persist(new ItemAdded(cartId, cmd.itemId(), cmd.quantity()))
+            .thenReply(cmd.replyTo(), updatedCart -> new Accepted(updatedCart.toSummary()));
       }
     }
 
     public ReplyEffect<Event, State> onRemoveItem(State state, RemoveItem cmd) {
-      if (state.hasItem(cmd.itemId)) {
+      if (state.hasItem(cmd.itemId())) {
         return Effect()
-            .persist(new ItemRemoved(cartId, cmd.itemId))
-            .thenReply(cmd.replyTo, updatedCart -> new Accepted(updatedCart.toSummary()));
+            .persist(new ItemRemoved(cartId, cmd.itemId()))
+            .thenReply(cmd.replyTo(), updatedCart -> new Accepted(updatedCart.toSummary()));
       } else {
-        return Effect().reply(cmd.replyTo, new Accepted(state.toSummary()));
+        return Effect().reply(cmd.replyTo(), new Accepted(state.toSummary()));
       }
     }
 
     public ReplyEffect<Event, State> onAdjustItemQuantity(State state, AdjustItemQuantity cmd) {
-      if (cmd.quantity <= 0) {
-        return Effect().reply(cmd.replyTo, new Rejected("Quantity must be greater than zero"));
-      } else if (state.hasItem(cmd.itemId)) {
+      if (cmd.quantity() <= 0) {
+        return Effect().reply(cmd.replyTo(), new Rejected("Quantity must be greater than zero"));
+      } else if (state.hasItem(cmd.itemId())) {
         return Effect()
-            .persist(new ItemQuantityAdjusted(cartId, cmd.itemId, cmd.quantity))
-            .thenReply(cmd.replyTo, updatedCart -> new Accepted(updatedCart.toSummary()));
+            .persist(new ItemQuantityAdjusted(cartId, cmd.itemId(), cmd.quantity()))
+            .thenReply(cmd.replyTo(), updatedCart -> new Accepted(updatedCart.toSummary()));
       } else {
         return Effect()
             .reply(
-                cmd.replyTo,
+                cmd.replyTo(),
                 new Rejected(
                     "Cannot adjust quantity for item '"
-                        + cmd.itemId
+                        + cmd.itemId()
                         + "'. Item not present on cart"));
       }
     }
 
     public ReplyEffect<Event, State> onCheckout(State state, Checkout cmd) {
       if (state.isEmpty()) {
-        return Effect().reply(cmd.replyTo, new Rejected("Cannot checkout an empty shopping cart"));
+        return Effect().reply(cmd.replyTo(), new Rejected("Cannot checkout an empty shopping cart"));
       } else {
         return Effect()
             .persist(new CheckedOut(cartId, Instant.now()))
-            .thenReply(cmd.replyTo, updatedCart -> new Accepted(updatedCart.toSummary()));
+            .thenReply(cmd.replyTo(), updatedCart -> new Accepted(updatedCart.toSummary()));
       }
     }
   }
@@ -424,27 +311,27 @@ public class ShoppingCart
     ReplyEffect<Event, State> onAddItem(AddItem cmd) {
       return Effect()
           .reply(
-              cmd.replyTo,
+              cmd.replyTo(),
               new Rejected("Can't add an item to an already checked out shopping cart"));
     }
 
     ReplyEffect<Event, State> onRemoveItem(RemoveItem cmd) {
       return Effect()
           .reply(
-              cmd.replyTo,
+              cmd.replyTo(),
               new Rejected("Can't remove an item from an already checked out shopping cart"));
     }
 
     ReplyEffect<Event, State> onAdjustItemQuantity(AdjustItemQuantity cmd) {
       return Effect()
           .reply(
-              cmd.replyTo,
+              cmd.replyTo(),
               new Rejected("Can't adjust item on an already checked out shopping cart"));
     }
 
     ReplyEffect<Event, State> onCheckout(Checkout cmd) {
       return Effect()
-          .reply(cmd.replyTo, new Rejected("Can't checkout already checked out shopping cart"));
+          .reply(cmd.replyTo(), new Rejected("Can't checkout already checked out shopping cart"));
     }
   }
 
@@ -452,12 +339,12 @@ public class ShoppingCart
   public EventHandler<State, Event> eventHandler() {
     return newEventHandlerBuilder()
         .forAnyState()
-        .onEvent(ItemAdded.class, (state, event) -> state.updateItem(event.itemId, event.quantity))
-        .onEvent(ItemRemoved.class, (state, event) -> state.removeItem(event.itemId))
+        .onEvent(ItemAdded.class, (state, event) -> state.updateItem(event.itemId(), event.quantity()))
+        .onEvent(ItemRemoved.class, (state, event) -> state.removeItem(event.itemId()))
         .onEvent(
             ItemQuantityAdjusted.class,
-            (state, event) -> state.updateItem(event.itemId, event.quantity))
-        .onEvent(CheckedOut.class, (state, event) -> state.checkout(event.eventTime))
+            (state, event) -> state.updateItem(event.itemId(), event.quantity()))
+        .onEvent(CheckedOut.class, (state, event) -> state.checkout(event.eventTime()))
         .build();
   }
 

--- a/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
+++ b/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
@@ -115,13 +115,13 @@ class Guardian {
                                       new ArrayList<>();
                                   for (int j = 0; j < adjustments; j++) {
                                     int newQuantity = getRandomNumber(1, MAX_QUANTITY);
-                                    int oldQuantity = itemAdded.quantity;
+                                    int oldQuantity = itemAdded.quantity();
                                     if (!itemQuantityAdjusted.isEmpty()) {
                                       oldQuantity =
                                           ((ShoppingCartEvents.ItemQuantityAdjusted)
                                                   itemQuantityAdjusted.get(
                                                       itemQuantityAdjusted.size() - 1))
-                                              .newQuantity;
+                                              .newQuantity();
                                     }
                                     itemQuantityAdjusted.add(
                                         new ShoppingCartEvents.ItemQuantityAdjusted(
@@ -137,7 +137,7 @@ class Guardian {
                                         ((ShoppingCartEvents.ItemQuantityAdjusted)
                                                 itemQuantityAdjusted.get(
                                                     itemQuantityAdjusted.size() - 1))
-                                            .newQuantity;
+                                            .newQuantity();
                                     itemRemoved.add(
                                         new ShoppingCartEvents.ItemRemoved(
                                             cartId, itemId, oldQuantity));
@@ -160,7 +160,7 @@ class Guardian {
               // send each event to the sharded entity represented by the event's cartId
               .runWith(
                   Sink.foreach(
-                      event -> sharding.entityRefFor(ENTITY_KEY, event.getCartId()).tell(event)),
+                      event -> sharding.entityRefFor(ENTITY_KEY, event.cartId()).tell(event)),
                   system);
 
           return Behaviors.empty();

--- a/examples/src/test/java/jdocs/guide/ItemPopularityProjectionHandler.java
+++ b/examples/src/test/java/jdocs/guide/ItemPopularityProjectionHandler.java
@@ -47,17 +47,13 @@ public class ItemPopularityProjectionHandler
       throws Exception {
     ShoppingCartEvents.Event event = envelope.event();
 
-    CompletionStage<Done> dbEffect = null;
-    if (event instanceof ShoppingCartEvents.ItemAdded) {
-      ShoppingCartEvents.ItemAdded added = (ShoppingCartEvents.ItemAdded) event;
-      dbEffect = this.repo.update(added.itemId, added.quantity);
-    } else if (event instanceof ShoppingCartEvents.ItemQuantityAdjusted) {
-      ShoppingCartEvents.ItemQuantityAdjusted adjusted =
-          (ShoppingCartEvents.ItemQuantityAdjusted) event;
-      dbEffect = this.repo.update(adjusted.itemId, adjusted.newQuantity - adjusted.oldQuantity);
-    } else if (event instanceof ShoppingCartEvents.ItemRemoved) {
-      ShoppingCartEvents.ItemRemoved removed = (ShoppingCartEvents.ItemRemoved) event;
-      dbEffect = this.repo.update(removed.itemId, 0 - removed.oldQuantity);
+    CompletionStage<Done> dbEffect;
+    if (event instanceof ShoppingCartEvents.ItemAdded added) {
+      dbEffect = this.repo.update(added.itemId(), added.quantity());
+    } else if (event instanceof ShoppingCartEvents.ItemQuantityAdjusted adjusted) {
+      dbEffect = this.repo.update(adjusted.itemId(), adjusted.newQuantity() - adjusted.oldQuantity());
+    } else if (event instanceof ShoppingCartEvents.ItemRemoved removed) {
+      dbEffect = this.repo.update(removed.itemId(), 0 - removed.oldQuantity());
     } else {
       // skip all other events, such as `CheckedOut`
       dbEffect = CompletableFuture.completedFuture(Done.getInstance());
@@ -70,12 +66,11 @@ public class ItemPopularityProjectionHandler
 
   /** Log the popularity of the item in every `ItemEvent` every `LogInterval`. */
   private void logItemCount(ShoppingCartEvents.Event event) {
-    if (event instanceof ShoppingCartEvents.ItemEvent) {
-      ShoppingCartEvents.ItemEvent itemEvent = (ShoppingCartEvents.ItemEvent) event;
+    if (event instanceof ShoppingCartEvents.ItemEvent itemEvent) {
       logCounter += 1;
       if (logCounter == LogInterval) {
         logCounter = 0;
-        String itemId = itemEvent.getItemId();
+        String itemId = itemEvent.itemId();
         repo.getItem(itemId)
             .thenAccept(
                 opt -> {

--- a/examples/src/test/java/jdocs/guide/ItemPopularityProjectionHandler.java
+++ b/examples/src/test/java/jdocs/guide/ItemPopularityProjectionHandler.java
@@ -51,7 +51,8 @@ public class ItemPopularityProjectionHandler
     if (event instanceof ShoppingCartEvents.ItemAdded added) {
       dbEffect = this.repo.update(added.itemId(), added.quantity());
     } else if (event instanceof ShoppingCartEvents.ItemQuantityAdjusted adjusted) {
-      dbEffect = this.repo.update(adjusted.itemId(), adjusted.newQuantity() - adjusted.oldQuantity());
+      dbEffect =
+          this.repo.update(adjusted.itemId(), adjusted.newQuantity() - adjusted.oldQuantity());
     } else if (event instanceof ShoppingCartEvents.ItemRemoved removed) {
       dbEffect = this.repo.update(removed.itemId(), 0 - removed.oldQuantity());
     } else {

--- a/examples/src/test/java/jdocs/guide/ShoppingCartEvents.java
+++ b/examples/src/test/java/jdocs/guide/ShoppingCartEvents.java
@@ -18,87 +18,20 @@ import java.time.Instant;
 
 public class ShoppingCartEvents {
   public interface Event extends CborSerializable {
-    String getCartId();
+    String cartId();
   }
 
   public interface ItemEvent extends Event {
-    String getItemId();
+    String itemId();
   }
 
-  public static final class ItemAdded implements ItemEvent {
-    public final String cartId;
-    public final String itemId;
-    public final int quantity;
+  public record ItemAdded(String cartId, String itemId, int quantity) implements ItemEvent {}
 
-    public ItemAdded(String cartId, String itemId, int quantity) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-      this.quantity = quantity;
-    }
+  public record ItemRemoved(String cartId, String itemId, int oldQuantity) implements ItemEvent {}
 
-    public String getCartId() {
-      return this.cartId;
-    }
+  public record ItemQuantityAdjusted(String cartId, String itemId, int newQuantity, int oldQuantity)
+      implements ItemEvent {}
 
-    public String getItemId() {
-      return this.itemId;
-    }
-  }
-
-  public static final class ItemRemoved implements ItemEvent {
-    public final String cartId;
-    public final String itemId;
-    public final int oldQuantity;
-
-    public ItemRemoved(String cartId, String itemId, int oldQuantity) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-      this.oldQuantity = oldQuantity;
-    }
-
-    public String getCartId() {
-      return this.cartId;
-    }
-
-    public String getItemId() {
-      return this.itemId;
-    }
-  }
-
-  public static final class ItemQuantityAdjusted implements ItemEvent {
-    public final String cartId;
-    public final String itemId;
-    public final int newQuantity;
-    public final int oldQuantity;
-
-    public ItemQuantityAdjusted(String cartId, String itemId, int newQuantity, int oldQuantity) {
-      this.cartId = cartId;
-      this.itemId = itemId;
-      this.newQuantity = newQuantity;
-      this.oldQuantity = oldQuantity;
-    }
-
-    public String getCartId() {
-      return this.cartId;
-    }
-
-    public String getItemId() {
-      return this.itemId;
-    }
-  }
-
-  public static final class CheckedOut implements Event {
-    public final String cartId;
-    public final Instant eventTime;
-
-    public CheckedOut(String cartId, Instant eventTime) {
-      this.cartId = cartId;
-      this.eventTime = eventTime;
-    }
-
-    public String getCartId() {
-      return this.cartId;
-    }
-  }
+  public record CheckedOut(String cartId, Instant eventTime) implements Event {}
 }
 // #guideEvents

--- a/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
+++ b/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
@@ -61,17 +61,7 @@ public class JdbcHibernateTest extends JUnitSuite {
 
   private final ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
 
-  static class Envelope {
-    final String id;
-    final long offset;
-    final String message;
-
-    Envelope(String id, long offset, String message) {
-      this.id = id;
-      this.offset = offset;
-      this.message = message;
-    }
-  }
+  record Envelope(String id, long offset, String message) {}
 
   private static final HibernateSessionFactory sessionProvider = new HibernateSessionFactory();
 
@@ -99,7 +89,7 @@ public class JdbcHibernateTest extends JUnitSuite {
                 new Envelope(entityId, 6, "pqr")));
 
     TestSourceProvider<Long, Envelope> sourceProvider =
-        TestSourceProvider.create(envelopes, env -> env.offset)
+        TestSourceProvider.create(envelopes, env -> env.offset())
             .withStartSourceFrom(
                 (Long lastProcessedOffset, Long offset) -> offset <= lastProcessedOffset);
 
@@ -110,7 +100,7 @@ public class JdbcHibernateTest extends JUnitSuite {
     return new JdbcHandler<Envelope, HibernateJdbcSession>() {
       @Override
       public void process(HibernateJdbcSession session, Envelope envelope) {
-        buffer.append(envelope.message).append("|");
+        buffer.append(envelope.message()).append("|");
       }
     };
   }

--- a/examples/src/test/java/jdocs/jdbc/JdbcProjectionDocExample.java
+++ b/examples/src/test/java/jdocs/jdbc/JdbcProjectionDocExample.java
@@ -142,7 +142,9 @@ class JdbcProjectionDocExample {
         ShoppingCart.Event event = envelope.event();
         if (event instanceof ShoppingCart.CheckedOut checkedOut) {
           logger.info(
-              "Shopping cart {} was checked out at {}", checkedOut.cartId(), checkedOut.eventTime());
+              "Shopping cart {} was checked out at {}",
+              checkedOut.cartId(),
+              checkedOut.eventTime());
 
           // pass the EntityManager created by the projection
           // to the repository in order to use the same transaction

--- a/examples/src/test/java/jdocs/jdbc/JdbcProjectionDocExample.java
+++ b/examples/src/test/java/jdocs/jdbc/JdbcProjectionDocExample.java
@@ -51,15 +51,7 @@ class JdbcProjectionDocExample {
   // #todo
 
   // #repository
-  class Order {
-    public final String id;
-    public final Instant time;
-
-    public Order(String id, Instant time) {
-      this.id = id;
-      this.time = time;
-    }
-  }
+  record Order(String id, Instant time) {}
 
   interface OrderRepository {
     void save(EntityManager entityManager, Order order);
@@ -121,17 +113,16 @@ class JdbcProjectionDocExample {
     public void process(HibernateJdbcSession session, EventEnvelope<ShoppingCart.Event> envelope)
         throws Exception {
       ShoppingCart.Event event = envelope.event();
-      if (event instanceof ShoppingCart.CheckedOut) {
-        ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+      if (event instanceof ShoppingCart.CheckedOut checkedOut) {
         logger.info(
-            "Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+            "Shopping cart {} was checked out at {}", checkedOut.cartId(), checkedOut.eventTime());
 
         // pass the EntityManager created by the projection
         // to the repository in order to use the same transaction
         orderRepository.save(
-            session.entityManager, new Order(checkedOut.cartId, checkedOut.eventTime));
+            session.entityManager, new Order(checkedOut.cartId(), checkedOut.eventTime()));
       } else {
-        logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+        logger.debug("Shopping cart {} changed by {}", event.cartId(), event);
       }
     }
   }
@@ -149,18 +140,17 @@ class JdbcProjectionDocExample {
         throws Exception {
       for (EventEnvelope<ShoppingCart.Event> envelope : envelopes) {
         ShoppingCart.Event event = envelope.event();
-        if (event instanceof ShoppingCart.CheckedOut) {
-          ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+        if (event instanceof ShoppingCart.CheckedOut checkedOut) {
           logger.info(
-              "Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+              "Shopping cart {} was checked out at {}", checkedOut.cartId(), checkedOut.eventTime());
 
           // pass the EntityManager created by the projection
           // to the repository in order to use the same transaction
           orderRepository.save(
-              session.entityManager, new Order(checkedOut.cartId, checkedOut.eventTime));
+              session.entityManager, new Order(checkedOut.cartId(), checkedOut.eventTime()));
 
         } else {
-          logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+          logger.debug("Shopping cart {} changed by {}", event.cartId(), event);
         }
       }
     }

--- a/examples/src/test/java/jdocs/kafka/KafkaDocExample.java
+++ b/examples/src/test/java/jdocs/kafka/KafkaDocExample.java
@@ -110,15 +110,7 @@ public interface KafkaDocExample {
   // #handler
 
   // #wordSource
-  public class WordEnvelope {
-    public final Long offset;
-    public final String word;
-
-    public WordEnvelope(Long offset, String word) {
-      this.offset = offset;
-      this.word = word;
-    }
-  }
+  public record WordEnvelope(Long offset, String word) {}
 
   class WordSource extends SourceProvider<Long, WordEnvelope> {
 
@@ -138,7 +130,7 @@ public interface KafkaDocExample {
           .thenApply(
               o -> {
                 if (o.isPresent())
-                  return src.dropWhile(envelope -> envelope.offset <= o.get())
+                  return src.dropWhile(envelope -> envelope.offset() <= o.get())
                       .throttle(1, Duration.ofSeconds(1));
                 else return src.throttle(1, Duration.ofSeconds(1));
               });
@@ -146,7 +138,7 @@ public interface KafkaDocExample {
 
     @Override
     public Long extractOffset(WordEnvelope envelope) {
-      return envelope.offset;
+      return envelope.offset();
     }
 
     @Override
@@ -170,7 +162,7 @@ public interface KafkaDocExample {
 
     @Override
     public CompletionStage<Done> process(WordEnvelope envelope) {
-      String word = envelope.word;
+      String word = envelope.word();
       // using the word as the key and `DefaultPartitioner` will select partition based on the key
       // so that same word always ends up in same partition
       String key = word;
@@ -307,7 +299,7 @@ public interface KafkaDocExample {
                     wordEnv ->
                         ProducerMessage.single(
                             new ProducerRecord<String, String>(
-                                topicName, wordEnv.word, wordEnv.word)))
+                                topicName, wordEnv.word(), wordEnv.word())))
                 .via(Producer.flowWithContext(producerSettings))
                 .map(__ -> Done.getInstance());
 

--- a/integration-examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
+++ b/integration-examples/src/test/java/jdocs/cassandra/CassandraProjectionDocExample.java
@@ -89,13 +89,12 @@ public interface CassandraProjectionDocExample {
     @Override
     public CompletionStage<Done> process(EventEnvelope<ShoppingCart.Event> envelope) {
       ShoppingCart.Event event = envelope.event();
-      if (event instanceof ShoppingCart.CheckedOut) {
-        ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+      if (event instanceof ShoppingCart.CheckedOut checkedOut) {
         logger.info(
-            "Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+            "Shopping cart {} was checked out at {}", checkedOut.cartId(), checkedOut.eventTime());
         return CompletableFuture.completedFuture(Done.getInstance());
       } else {
-        logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+        logger.debug("Shopping cart {} changed by {}", event.cartId(), event);
         return CompletableFuture.completedFuture(Done.getInstance());
       }
     }
@@ -112,14 +111,13 @@ public interface CassandraProjectionDocExample {
       envelopes.forEach(
           env -> {
             ShoppingCart.Event event = env.event();
-            if (event instanceof ShoppingCart.CheckedOut) {
-              ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+            if (event instanceof ShoppingCart.CheckedOut checkedOut) {
               logger.info(
                   "Shopping cart {} was checked out at {}",
-                  checkedOut.cartId,
-                  checkedOut.eventTime);
+                  checkedOut.cartId(),
+                  checkedOut.eventTime());
             } else {
-              logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+              logger.debug("Shopping cart {} changed by {}", event.cartId(), event);
             }
           });
       return CompletableFuture.completedFuture(Done.getInstance());
@@ -201,14 +199,13 @@ public interface CassandraProjectionDocExample {
                 .map(EventEnvelope::event)
                 .map(
                     event -> {
-                      if (event instanceof ShoppingCart.CheckedOut) {
-                        ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+                      if (event instanceof ShoppingCart.CheckedOut checkedOut) {
                         logger.info(
                             "Shopping cart {} was checked out at {}",
-                            checkedOut.cartId,
-                            checkedOut.eventTime);
+                            checkedOut.cartId(),
+                            checkedOut.eventTime());
                       } else {
-                        logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+                        logger.debug("Shopping cart {} changed by {}", event.cartId(), event);
                       }
                       return Done.getInstance();
                     });

--- a/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExample.java
+++ b/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExample.java
@@ -59,15 +59,7 @@ public interface WordCountDocExample {
   // #todo
 
   // #envelope
-  public class WordEnvelope {
-    public final Long offset;
-    public final String word;
-
-    public WordEnvelope(Long offset, String word) {
-      this.offset = offset;
-      this.word = word;
-    }
-  }
+  public record WordEnvelope(Long offset, String word) {}
 
   // #envelope
 
@@ -131,13 +123,14 @@ public interface WordCountDocExample {
           .thenCompose(
               done ->
                   session.executeDDL(
-                      "CREATE TABLE IF NOT EXISTS "
-                          + keyspaceTable
-                          + " (\n"
-                          + "  id text, \n"
-                          + "  word text, \n"
-                          + "  count int, \n"
-                          + "  PRIMARY KEY (id, word)) \n"));
+                      """
+                      CREATE TABLE IF NOT EXISTS %s (
+                        id text,
+                        word text,
+                        count int,
+                        PRIMARY KEY (id, word))
+                      """
+                          .formatted(keyspaceTable)));
     }
   }
 
@@ -159,14 +152,14 @@ public interface WordCountDocExample {
           .get()
           .thenApply(
               o -> {
-                if (o.isPresent()) return src.dropWhile(envelope -> envelope.offset <= o.get());
+                if (o.isPresent()) return src.dropWhile(envelope -> envelope.offset() <= o.get());
                 else return src;
               });
     }
 
     @Override
     public Long extractOffset(WordEnvelope envelope) {
-      return envelope.offset;
+      return envelope.offset();
     }
 
     @Override
@@ -185,7 +178,7 @@ public interface WordCountDocExample {
 
       @Override
       public CompletionStage<Done> process(WordEnvelope envelope) {
-        String word = envelope.word;
+        String word = envelope.word();
         int newCount = state.getOrDefault(word, 0) + 1;
         logger.info("Word count for {} is {}", word, newCount);
         state.put(word, newCount);
@@ -214,7 +207,7 @@ public interface WordCountDocExample {
       @Override
       public CompletionStage<Map<String, Integer>> process(
           Map<String, Integer> state, WordEnvelope envelope) {
-        String word = envelope.word;
+        String word = envelope.word();
         int newCount = state.getOrDefault(word, 0) + 1;
         CompletionStage<Map<String, Integer>> newState =
             repository
@@ -250,7 +243,7 @@ public interface WordCountDocExample {
       @Override
       public CompletionStage<Map<String, Integer>> process(
           Map<String, Integer> state, WordEnvelope envelope) {
-        String word = envelope.word;
+        String word = envelope.word();
 
         CompletionStage<Integer> currentCount;
         if (state.containsKey(word))
@@ -300,9 +293,9 @@ public interface WordCountDocExample {
 
         return result.thenCompose(
             r -> {
-              if (r.error.isPresent()) {
+              if (r.error().isPresent()) {
                 CompletableFuture<Done> err = new CompletableFuture<>();
-                err.completeExceptionally(r.error.get());
+                err.completeExceptionally(r.error().get());
                 return err;
               } else {
                 return CompletableFuture.completedFuture(Done.getInstance());
@@ -317,43 +310,14 @@ public interface WordCountDocExample {
     public class WordCountProcessor {
       public interface Command {}
 
-      public static class Handle implements Command {
-        public final WordEnvelope envelope;
-        public final ActorRef<Result> replyTo;
+      public record Handle(WordEnvelope envelope, ActorRef<Result> replyTo) implements Command {}
 
-        public Handle(WordEnvelope envelope, ActorRef<Result> replyTo) {
-          this.envelope = envelope;
-          this.replyTo = replyTo;
-        }
-      }
+      public record Result(Optional<Throwable> error) {}
 
-      public static class Result {
-        public final Optional<Throwable> error;
+      private record InitialState(Map<String, Integer> state) implements Command {}
 
-        public Result(Optional<Throwable> error) {
-          this.error = error;
-        }
-      }
-
-      private static class InitialState implements Command {
-        final Map<String, Integer> state;
-
-        private InitialState(Map<String, Integer> state) {
-          this.state = state;
-        }
-      }
-
-      private static class SaveCompleted implements Command {
-        final String word;
-        final Optional<Throwable> error;
-        final ActorRef<Result> replyTo;
-
-        private SaveCompleted(String word, Optional<Throwable> error, ActorRef<Result> replyTo) {
-          this.word = word;
-          this.error = error;
-          this.replyTo = replyTo;
-        }
-      }
+      private record SaveCompleted(String word, Optional<Throwable> error, ActorRef<Result> replyTo)
+          implements Command {}
 
       public static Behavior<Command> create(
           ProjectionId projectionId, WordCountRepository repository) {
@@ -403,8 +367,8 @@ public interface WordCountDocExample {
         }
 
         private Behavior<Command> onInitalState(InitialState initialState) {
-          getContext().getLog().debug("Initial state [{}]", initialState.state);
-          return buffer.unstashAll(new Active(getContext(), initialState.state));
+          getContext().getLog().debug("Initial state [{}]", initialState.state());
+          return buffer.unstashAll(new Active(getContext(), initialState.state()));
         }
 
         private Behavior<Command> onOther(Command command) {
@@ -431,24 +395,24 @@ public interface WordCountDocExample {
         }
 
         private Behavior<Command> onHandle(Handle command) {
-          String word = command.envelope.word;
+          String word = command.envelope().word();
           int newCount = state.getOrDefault(word, 0) + 1;
           getContext()
               .pipeToSelf(
                   repository.save(projectionId.id(), word, newCount),
                   (done, exc) ->
                       // will reply from SaveCompleted
-                      new SaveCompleted(word, Optional.ofNullable(exc), command.replyTo));
+                      new SaveCompleted(word, Optional.ofNullable(exc), command.replyTo()));
           return this;
         }
 
         private Behavior<Command> onSaveCompleted(SaveCompleted completed) {
-          completed.replyTo.tell(new Result(completed.error));
-          if (completed.error.isPresent()) {
+          completed.replyTo().tell(new Result(completed.error()));
+          if (completed.error().isPresent()) {
             // restart, reload state from db
-            throw new RuntimeException("Save failed.", completed.error.get());
+            throw new RuntimeException("Save failed.", completed.error().get());
           } else {
-            String word = completed.word;
+            String word = completed.word();
             int newCount = state.getOrDefault(word, 0) + 1;
             state.put(word, newCount);
           }
@@ -484,9 +448,9 @@ public interface WordCountDocExample {
 
         return result.thenCompose(
             r -> {
-              if (r.error.isPresent()) {
+              if (r.error().isPresent()) {
                 CompletableFuture<Done> err = new CompletableFuture<>();
-                err.completeExceptionally(r.error.get());
+                err.completeExceptionally(r.error().get());
                 return err;
               } else {
                 return CompletableFuture.completedFuture(Done.getInstance());
@@ -499,47 +463,15 @@ public interface WordCountDocExample {
     public class WordCountProcessor extends AbstractBehavior<WordCountProcessor.Command> {
       public interface Command {}
 
-      public static class Handle implements Command {
-        public final WordEnvelope envelope;
-        public final ActorRef<Result> replyTo;
+      public record Handle(WordEnvelope envelope, ActorRef<Result> replyTo) implements Command {}
 
-        public Handle(WordEnvelope envelope, ActorRef<Result> replyTo) {
-          this.envelope = envelope;
-          this.replyTo = replyTo;
-        }
-      }
+      public record Result(Optional<Throwable> error) {}
 
-      public static class Result {
-        public final Optional<Throwable> error;
+      private record LoadCompleted(String word, Optional<Throwable> error, ActorRef<Result> replyTo)
+          implements Command {}
 
-        public Result(Optional<Throwable> error) {
-          this.error = error;
-        }
-      }
-
-      private static class LoadCompleted implements Command {
-        final String word;
-        final Optional<Throwable> error;
-        final ActorRef<Result> replyTo;
-
-        private LoadCompleted(String word, Optional<Throwable> error, ActorRef<Result> replyTo) {
-          this.word = word;
-          this.error = error;
-          this.replyTo = replyTo;
-        }
-      }
-
-      private static class SaveCompleted implements Command {
-        final String word;
-        final Optional<Throwable> error;
-        final ActorRef<Result> replyTo;
-
-        private SaveCompleted(String word, Optional<Throwable> error, ActorRef<Result> replyTo) {
-          this.word = word;
-          this.error = error;
-          this.replyTo = replyTo;
-        }
-      }
+      private record SaveCompleted(String word, Optional<Throwable> error, ActorRef<Result> replyTo)
+          implements Command {}
 
       public static Behavior<Command> create(
           ProjectionId projectionId, WordCountRepository repository) {
@@ -575,7 +507,7 @@ public interface WordCountDocExample {
       }
 
       private Behavior<Command> onHandle(Handle command) {
-        String word = command.envelope.word;
+        String word = command.envelope().word();
         if (state.containsKey(word)) {
           int newCount = state.get(word) + 1;
           getContext()
@@ -583,42 +515,42 @@ public interface WordCountDocExample {
                   repository.save(projectionId.id(), word, newCount),
                   (done, exc) ->
                       // will reply from SaveCompleted
-                      new SaveCompleted(word, Optional.ofNullable(exc), command.replyTo));
+                      new SaveCompleted(word, Optional.ofNullable(exc), command.replyTo()));
         } else {
           getContext()
               .pipeToSelf(
                   repository.load(projectionId.id(), word),
                   (loadResult, exc) ->
                       // will reply from LoadCompleted
-                      new LoadCompleted(word, Optional.ofNullable(exc), command.replyTo));
+                      new LoadCompleted(word, Optional.ofNullable(exc), command.replyTo()));
         }
         return this;
       }
 
       private Behavior<Command> onLoadCompleted(LoadCompleted completed) {
-        if (completed.error.isPresent()) {
-          completed.replyTo.tell(new Result(completed.error));
+        if (completed.error().isPresent()) {
+          completed.replyTo().tell(new Result(completed.error()));
         } else {
-          String word = completed.word;
+          String word = completed.word();
           int newCount = state.getOrDefault(word, 0) + 1;
           getContext()
               .pipeToSelf(
                   repository.save(projectionId.id(), word, newCount),
                   (done, exc) ->
                       // will reply from SaveCompleted
-                      new SaveCompleted(word, Optional.ofNullable(exc), completed.replyTo));
+                      new SaveCompleted(word, Optional.ofNullable(exc), completed.replyTo()));
         }
         return this;
       }
 
       private Behavior<Command> onSaveCompleted(SaveCompleted completed) {
-        completed.replyTo.tell(new Result(completed.error));
-        if (completed.error.isPresent()) {
+        completed.replyTo().tell(new Result(completed.error()));
+        if (completed.error().isPresent()) {
           // remove the word from the state if the save failed, because it could have been a timeout
           // so that it was actually saved, best to reload
-          state.remove(completed.word);
+          state.remove(completed.word());
         } else {
-          String word = completed.word;
+          String word = completed.word();
           int newCount = state.getOrDefault(word, 0) + 1;
           state.put(word, newCount);
         }

--- a/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
+++ b/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
@@ -139,17 +139,7 @@ public class JdbcProjectionTest extends JUnitSuite {
     Await.result(offsetStore.createIfNotExists(), awaitTimeout);
   }
 
-  static class Envelope {
-    final String id;
-    final long offset;
-    final String message;
-
-    Envelope(String id, long offset, String message) {
-      this.id = id;
-      this.offset = offset;
-      this.message = message;
-    }
-  }
+  record Envelope(String id, long offset, String message) {}
 
   public static SourceProvider<Long, Envelope> sourceProvider(String entityId) {
     Source<Envelope, NotUsed> envelopes =
@@ -163,7 +153,7 @@ public class JdbcProjectionTest extends JUnitSuite {
                 new Envelope(entityId, 6, "pqr")));
 
     TestSourceProvider<Long, Envelope> sourceProvider =
-        TestSourceProvider.create(envelopes, env -> env.offset)
+        TestSourceProvider.create(envelopes, env -> env.offset())
             .withStartSourceFrom(
                 (Long lastProcessedOffset, Long offset) -> offset <= lastProcessedOffset);
 
@@ -217,11 +207,11 @@ public class JdbcProjectionTest extends JUnitSuite {
       StringBuffer buffer, CountDownLatch latch, Predicate<Long> failPredicate) {
     return JdbcHandler.fromFunction(
         (PureJdbcSession session, Envelope envelope) -> {
-          if (failPredicate.test(envelope.offset)) {
+          if (failPredicate.test(envelope.offset())) {
             latch.countDown();
-            throw new RuntimeException(failMessage(envelope.offset));
+            throw new RuntimeException(failMessage(envelope.offset()));
           } else {
-            buffer.append(envelope.message).append("|");
+            buffer.append(envelope.message()).append("|");
             latch.countDown();
           }
         });
@@ -246,7 +236,7 @@ public class JdbcProjectionTest extends JUnitSuite {
     public void process(PureJdbcSession session, List<Envelope> envelopes) {
       handlerProbe.ref().tell(GroupedConcatHandler.handlerCalled);
       for (Envelope envelope : envelopes) {
-        buffer.append(envelope.message).append("|");
+        buffer.append(envelope.message()).append("|");
       }
     }
   }
@@ -418,7 +408,7 @@ public class JdbcProjectionTest extends JUnitSuite {
         FlowWithContext.<Envelope, ProjectionContext>create()
             .map(
                 envelope -> {
-                  str.append(envelope.message).append("|");
+                  str.append(envelope.message()).append("|");
                   return Done.getInstance();
                 });
 

--- a/r2dbc/src/test/java/jdocs/home/projection/R2dbcProjectionDocExample.java
+++ b/r2dbc/src/test/java/jdocs/home/projection/R2dbcProjectionDocExample.java
@@ -127,7 +127,9 @@ class R2dbcProjectionDocExample {
         ShoppingCart.Event event = envelope.event();
         if (event instanceof ShoppingCart.CheckedOut checkedOut) {
           logger.info(
-              "Shopping cart {} was checked out at {}", checkedOut.cartId(), checkedOut.eventTime());
+              "Shopping cart {} was checked out at {}",
+              checkedOut.cartId(),
+              checkedOut.eventTime());
 
           Statement stmt =
               session

--- a/r2dbc/src/test/java/jdocs/home/projection/R2dbcProjectionDocExample.java
+++ b/r2dbc/src/test/java/jdocs/home/projection/R2dbcProjectionDocExample.java
@@ -75,23 +75,10 @@ class R2dbcProjectionDocExample {
     interface Command extends CborSerializable {}
 
     interface Event {
-      String getCartId();
+      String cartId();
     }
 
-    public static class CheckedOut implements Event {
-
-      public final String cartId;
-      public final Instant eventTime;
-
-      public CheckedOut(String cartId, Instant eventTime) {
-        this.cartId = cartId;
-        this.eventTime = eventTime;
-      }
-
-      public String getCartId() {
-        return cartId;
-      }
-
+    public record CheckedOut(String cartId, Instant eventTime) implements Event {
       @Override
       public String toString() {
         return "CheckedOut(" + cartId + "," + eventTime + ")";
@@ -107,20 +94,19 @@ class R2dbcProjectionDocExample {
     public CompletionStage<Done> process(
         R2dbcSession session, EventEnvelope<ShoppingCart.Event> envelope) {
       ShoppingCart.Event event = envelope.event();
-      if (event instanceof ShoppingCart.CheckedOut) {
-        ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+      if (event instanceof ShoppingCart.CheckedOut checkedOut) {
         logger.info(
-            "Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+            "Shopping cart {} was checked out at {}", checkedOut.cartId(), checkedOut.eventTime());
 
         Statement stmt =
             session
                 .createStatement("INSERT into order (id, time) VALUES ($1, $2)")
-                .bind(0, checkedOut.cartId)
-                .bind(1, checkedOut.eventTime);
+                .bind(0, checkedOut.cartId())
+                .bind(1, checkedOut.eventTime());
         return session.updateOne(stmt).thenApply(rowsUpdated -> Done.getInstance());
 
       } else {
-        logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+        logger.debug("Shopping cart {} changed by {}", event.cartId(), event);
         return CompletableFuture.completedFuture(Done.getInstance());
       }
     }
@@ -139,19 +125,18 @@ class R2dbcProjectionDocExample {
       List<Statement> stmts = new ArrayList<>();
       for (EventEnvelope<ShoppingCart.Event> envelope : envelopes) {
         ShoppingCart.Event event = envelope.event();
-        if (event instanceof ShoppingCart.CheckedOut) {
-          ShoppingCart.CheckedOut checkedOut = (ShoppingCart.CheckedOut) event;
+        if (event instanceof ShoppingCart.CheckedOut checkedOut) {
           logger.info(
-              "Shopping cart {} was checked out at {}", checkedOut.cartId, checkedOut.eventTime);
+              "Shopping cart {} was checked out at {}", checkedOut.cartId(), checkedOut.eventTime());
 
           Statement stmt =
               session
                   .createStatement("INSERT into order (id, time) VALUES ($1, $2)")
-                  .bind(0, checkedOut.cartId)
-                  .bind(1, checkedOut.eventTime);
+                  .bind(0, checkedOut.cartId())
+                  .bind(1, checkedOut.eventTime());
           stmts.add(stmt);
         } else {
-          logger.debug("Shopping cart {} changed by {}", event.getCartId(), event);
+          logger.debug("Shopping cart {} changed by {}", event.cartId(), event);
         }
       }
 


### PR DESCRIPTION
### Motivation
Java 17 introduced records, pattern matching for instanceof, text blocks, and other features that make Java code more concise and readable. The test and example code contained many verbose data carrier classes and instanceof + explicit cast patterns that can be significantly simplified.

### Modification
- Convert data carrier classes (commands, events, envelopes, results) to Java records across all test and example modules
- Use pattern matching for instanceof to eliminate explicit casts
- Use text blocks for multi-line SQL DDL strings
- Update interface methods from `getXxx()` to `xxx()` style to match record accessor conventions
- Update all field accesses from direct field access (`obj.field`) to record accessor method calls (`obj.field()`)

Files changed:
- `examples/`: ShoppingCart, ShoppingCartEvents, EventGeneratorApp, ItemPopularityProjectionHandler, JdbcProjectionDocExample, JdbcHibernateTest, KafkaDocExample
- `integration-examples/`: CassandraProjectionDocExample, WordCountDocExample
- `r2dbc/`: R2dbcProjectionDocExample
- `cassandra-test/`: CassandraProjectionTest
- `jdbc/`: JdbcProjectionTest

### Result
Test and example Java code is more concise and idiomatic for Java 17+, reducing boilerplate while maintaining the same behavior. Net reduction of ~330 lines of code across 12 files.

### Tests
- `sbt "examples / compile"` (to be verified by CI)
- `sbt "integration-examples / compile"` (to be verified by CI)
- `sbt "cassandra-test / Test / compile"` (to be verified by CI)
- `sbt "jdbc / Test / compile"` (to be verified by CI)

### References
None - code modernization