### PR TITLE
docs: add mandatory header workflow reminder to Licensing Rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ If this file conflicts with community conventions, update this file.
 
 ## Licensing Rules
 
+> **⚠️ Mandatory workflow for new files:** Create the file without any header → run `sbt headerCreateAll` → sbt adds the correct header automatically. Never hand-write or copy-paste a license header.
+
 - Do not hand-write or invent license headers. Let sbt manage them.
 - For new files, run `sbt headerCreateAll` to add the correct header. Do not manually paste header text.
 - Run `sbt +headerCheckAll` to verify all files carry the expected header.


### PR DESCRIPTION
### Motivation
The existing Licensing Rules already state "Do not hand-write or invent license headers. Let sbt manage them" and "For new files, run `sbt headerCreateAll`", but agents can still miss these rules and hand-write a header (e.g. accidentally using the Akka-derived header for new code).

### Modification
Add a prominent blockquote reminder at the top of the Licensing Rules section that spells out the mandatory workflow in one line: create file without header → `sbt headerCreateAll` → done.

### Result
Agents see the workflow before reading the detailed rules, reducing the chance of hand-writing an incorrect header.

### Tests
Not run - docs only

### References
None - process improvement