### PR TITLE
Revert sbt-salad-days to fix missing maven-metadata.xml

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -29,6 +29,3 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 
 addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "2.0.0-M2")
-
-// https://eed3si9n.com/reducing-scaladoc-file-size-with-sbt-salad-days/
-addSbtPlugin("com.eed3si9n" % "sbt-salad-days" % "0.1.0")


### PR DESCRIPTION
### Motivation

After merging #533 (sbt-salad-days), the nightly publish build (#198, commit 582b175f) uploaded all artifacts successfully but `maven-metadata.xml` is missing from the snapshot directory for both `_2.13` and `_3` variants. The parent-level `maven-metadata.xml` also was not updated to include version `2.0.0-M0+198-582b175f-SNAPSHOT`.

While the plugin code only modifies Scala 3 `Compile / packageDoc / mappings` and is unlikely the direct cause, reverting is the safest way to rule it out and restore working snapshot metadata.

### Modification

Revert the addition of `sbt-salad-days` 0.1.0 from `project/plugins.sbt` (3 lines removed).

### Result

Restores the build to the state of #197 where `maven-metadata.xml` was correctly generated by Nexus. If the next nightly build produces metadata, the plugin was the cause; if not, it confirms a Nexus-side issue.

### Tests

- Not run - build configuration revert only

### References

Refs #533