### PR TITLE
refactor: migrate Collections/Arrays.asList to Java 9+ collection factories

### DIFF
--- a/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
+++ b/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
@@ -16,7 +16,6 @@ package org.apache.pekko.projection.cassandra;
 import static org.junit.Assert.assertEquals;
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -100,7 +99,7 @@ public class CassandraProjectionTest extends JUnitSuite {
   public static SourceProvider<Long, Envelope> sourceProvider(String entityId) {
     Source<Envelope, NotUsed> envelopes =
         Source.from(
-            Arrays.asList(
+            List.of(
                 new Envelope(entityId, 1, "abc"),
                 new Envelope(entityId, 2, "def"),
                 new Envelope(entityId, 3, "ghi"),

--- a/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
+++ b/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
@@ -202,8 +202,7 @@ public class ShoppingCart
 
   // #slicingTags
   public static final List<String> tags =
-      Collections.unmodifiableList(
-          Arrays.asList("carts-0", "carts-1", "carts-2", "carts-3", "carts-4"));
+      List.of("carts-0", "carts-1", "carts-2", "carts-3", "carts-4");
 
   // #slicingTags
 
@@ -212,7 +211,7 @@ public class ShoppingCart
   public Set<String> tagsFor(Event event) {
     int n = Math.abs(cartId.hashCode() % tags.size());
     String selectedTag = tags.get(n);
-    return Collections.singleton(selectedTag);
+    return Set.of(selectedTag);
   }
 
   // #tagging

--- a/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
+++ b/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
@@ -60,7 +60,7 @@ public class EventGeneratorApp {
 
 class Guardian {
   static final List<String> PRODUCTS =
-      Arrays.asList("cat t-shirt", "pekko t-shirt", "skis", "bowling shoes");
+      List.of("cat t-shirt", "pekko t-shirt", "skis", "bowling shoes");
 
   static final int MAX_QUANTITY = 5;
   static final int MAX_ITEMS = 3;
@@ -197,7 +197,7 @@ class Guardian {
     public CartPersistentBehavior(PersistenceId persistenceId, String tag) {
       super(persistenceId);
       this.tag = tag;
-      this.tags = new HashSet<>(Collections.singletonList(tag));
+      this.tags = new HashSet<>(List.of(tag));
     }
 
     @Override

--- a/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
+++ b/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
@@ -197,7 +197,7 @@ class Guardian {
     public CartPersistentBehavior(PersistenceId persistenceId, String tag) {
       super(persistenceId);
       this.tag = tag;
-      this.tags = new HashSet<>(List.of(tag));
+      this.tags = Set.of(tag);
     }
 
     @Override

--- a/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
+++ b/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
@@ -17,8 +17,8 @@ package jdocs.guide;
 import static org.junit.Assert.assertEquals;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -60,7 +60,7 @@ public class ShoppingCartAppTest {
 
     Source<EventEnvelope<ShoppingCartEvents.Event>, NotUsed> events =
         Source.from(
-            Arrays.asList(
+            List.of(
                 createEnvelope(
                     new ShoppingCartEvents.ItemAdded("a7098", "bowling shoes", 1), 0L, 0L),
                 createEnvelope(

--- a/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
+++ b/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
@@ -17,8 +17,8 @@ import static org.junit.Assert.assertEquals;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -80,7 +80,7 @@ public class JdbcHibernateTest extends JUnitSuite {
   public static SourceProvider<Long, Envelope> sourceProvider(String entityId) {
     Source<Envelope, NotUsed> envelopes =
         Source.from(
-            Arrays.asList(
+            List.of(
                 new Envelope(entityId, 1, "abc"),
                 new Envelope(entityId, 2, "def"),
                 new Envelope(entityId, 3, "ghi"),

--- a/examples/src/test/java/jdocs/kafka/KafkaDocExample.java
+++ b/examples/src/test/java/jdocs/kafka/KafkaDocExample.java
@@ -14,11 +14,11 @@
 package jdocs.kafka;
 
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
@@ -116,7 +116,7 @@ public interface KafkaDocExample {
 
     private final Source<WordEnvelope, NotUsed> src =
         Source.from(
-            Arrays.asList(
+            List.of(
                 new WordEnvelope(1L, "abc"),
                 new WordEnvelope(2L, "def"),
                 new WordEnvelope(3L, "ghi"),
@@ -199,7 +199,7 @@ public interface KafkaDocExample {
             .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
     SourceProvider<MergeableOffset<Long>, ConsumerRecord<String, String>> sourceProvider =
-        KafkaSourceProvider.create(system, consumerSettings, Collections.singleton(topicName));
+        KafkaSourceProvider.create(system, consumerSettings, Set.of(topicName));
     // #sourceProvider
 
     return sourceProvider;

--- a/grpc-test/src/test/java/org/apache/pekko/projection/grpc/consumer/javadsl/ConsumerCompileTest.java
+++ b/grpc-test/src/test/java/org/apache/pekko/projection/grpc/consumer/javadsl/ConsumerCompileTest.java
@@ -13,8 +13,6 @@
 
 package org.apache.pekko.projection.grpc.consumer.javadsl;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -68,7 +66,7 @@ public class ConsumerCompileTest {
             GrpcClientSettings.fromConfig(
                 system.settings().config().getConfig("pekko.projection.grpc.consumer.client"),
                 system),
-            Collections.singletonList(ShoppingcartApiProto.javaDescriptor()));
+            List.of(ShoppingcartApiProto.javaDescriptor()));
 
     ShardedDaemonProcess.get(system)
         .init(
@@ -106,7 +104,7 @@ public class ConsumerCompileTest {
         system.settings().config().getString("pekko.projection.grpc.consumer.stream-id");
 
     List<ConsumerFilter.FilterCriteria> criteria =
-        Arrays.asList(
+        List.of(
             new ConsumerFilter.ExcludeTags(excludeTags),
             new ConsumerFilter.IncludeTags(includeTags));
 

--- a/grpc-test/src/test/java/org/apache/pekko/projection/grpc/producer/javadsl/ProducerCompileTest.java
+++ b/grpc-test/src/test/java/org/apache/pekko/projection/grpc/producer/javadsl/ProducerCompileTest.java
@@ -23,8 +23,8 @@ import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.persistence.query.typed.EventEnvelope;
 import org.apache.pekko.projection.grpc.producer.EventProducerSettings;
 
-import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
@@ -60,7 +60,7 @@ public class ProducerCompileTest {
     Function<HttpRequest, CompletionStage<HttpResponse>> eventProducerService =
         EventProducer.grpcServiceHandler(system, source);
     Function<HttpRequest, CompletionStage<HttpResponse>> eventProducerServiceWithMultiple =
-        EventProducer.grpcServiceHandler(system, Collections.singleton(source));
+        EventProducer.grpcServiceHandler(system, Set.of(source));
 
     @SuppressWarnings("unchecked")
     Function<HttpRequest, CompletionStage<HttpResponse>> service =

--- a/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExample.java
+++ b/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExample.java
@@ -34,8 +34,8 @@ import org.apache.pekko.actor.typed.javadsl.Receive;
 // #ActorHandler-imports
 
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -139,7 +139,7 @@ public interface WordCountDocExample {
 
     private final Source<WordEnvelope, NotUsed> src =
         Source.from(
-            Arrays.asList(
+            List.of(
                 new WordEnvelope(1L, "abc"),
                 new WordEnvelope(2L, "def"),
                 new WordEnvelope(3L, "ghi"),

--- a/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
+++ b/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
@@ -22,7 +22,6 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -144,7 +143,7 @@ public class JdbcProjectionTest extends JUnitSuite {
   public static SourceProvider<Long, Envelope> sourceProvider(String entityId) {
     Source<Envelope, NotUsed> envelopes =
         Source.from(
-            Arrays.asList(
+            List.of(
                 new Envelope(entityId, 1, "abc"),
                 new Envelope(entityId, 2, "def"),
                 new Envelope(entityId, 3, "ghi"),


### PR DESCRIPTION
### Motivation
Java 9+ provides `List.of()`, `Map.of()`, `Set.of()` factory methods that are more concise and return truly immutable collections.

### Modification
- Replace `Arrays.asList(...)` with `List.of()`
- Replace `Collections.singletonList()` with `List.of()`
- Replace `Collections.unmodifiableList(Arrays.asList(...))` with `List.of()`
- Replace `Collections.singleton()` with `Set.of()`
- Update imports accordingly

### Result
Cleaner code using Java 17 immutable collection factories. 10 files changed.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization