### PR TITLE
refactor: replace .collect(Collectors.toList()) with .toList()

### DIFF
--- a/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
+++ b/examples/src/test/java/jdocs/guide/EventGeneratorApp.java
@@ -19,7 +19,6 @@ import com.typesafe.config.ConfigFactory;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.pekko.actor.typed.ActorSystem;
@@ -155,7 +154,7 @@ class Guardian {
                     return Stream.concat(
                             itemEvents,
                             Stream.of(new ShoppingCartEvents.CheckedOut(cartId, Instant.now())))
-                        .collect(Collectors.toList());
+                        .toList();
                   })
               // send each event to the sharded entity represented by the event's cartId
               .runWith(

--- a/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
+++ b/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
@@ -35,7 +35,6 @@ import org.apache.pekko.projection.testkit.javadsl.ProjectionTestKit;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 // #testkit-duration
@@ -122,7 +121,7 @@ public class TestKitDocExample {
 
     // #testkit-testprojection
     List<Pair<Integer, String>> testData =
-        Stream.of(Pair.create(0, "abc"), Pair.create(1, "def")).collect(Collectors.toList());
+        Stream.of(Pair.create(0, "abc"), Pair.create(1, "def")).toList();
 
     Source<Pair<Integer, String>, NotUsed> source = Source.from(testData);
 

--- a/testkit/src/test/java/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKitTest.java
+++ b/testkit/src/test/java/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKitTest.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
@@ -51,8 +50,7 @@ import scala.jdk.javaapi.FutureConverters;
 
 public class ProjectionTestKitTest extends JUnitSuite {
 
-  private final List<Integer> elements =
-      IntStream.rangeClosed(1, 20).boxed().collect(Collectors.toList());
+  private final List<Integer> elements = IntStream.rangeClosed(1, 20).boxed().toList();
 
   private final Source<Integer, NotUsed> src = Source.from(elements);
 
@@ -145,7 +143,7 @@ public class ProjectionTestKitTest extends JUnitSuite {
   public void runAProjectionWithATestSink() {
 
     StringBuffer strBuffer = new StringBuffer();
-    List<Integer> elements = IntStream.rangeClosed(1, 5).boxed().collect(Collectors.toList());
+    List<Integer> elements = IntStream.rangeClosed(1, 5).boxed().toList();
 
     TestProjection prj = new TestProjection(Source.from(elements), strBuffer, i -> i <= 5);
 


### PR DESCRIPTION
### Motivation
Java 16+ `Stream.toList()` provides a concise way to collect stream elements into an unmodifiable list.

### Modification
Replace `.collect(Collectors.toList())` with `.toList()` across 3 files. Remove unused `Collectors` imports.

### Result
Cleaner stream collection code using Java 17 API.

### Tests
Not run - compile-only test file changes

### References
None - Java 17 API modernization