### PR TITLE
refactor: migrate String.format to String.formatted (Java 15+)

### DIFF
--- a/examples/src/test/java/jdocs/guide/ItemPopularityProjectionRepository.java
+++ b/examples/src/test/java/jdocs/guide/ItemPopularityProjectionRepository.java
@@ -48,7 +48,8 @@ class ItemPopularityProjectionRepositoryImpl implements ItemPopularityProjection
   public CompletionStage<Optional<Long>> getItem(String itemId) {
     return session
         .selectOne(
-            "SELECT item_id, count FROM %s.%s WHERE item_id = ?".formatted(Keyspace, PopularityTable),
+            "SELECT item_id, count FROM %s.%s WHERE item_id = ?"
+                .formatted(Keyspace, PopularityTable),
             itemId)
         .thenApply(opt -> opt.map(row -> row.getLong("count")));
   }

--- a/examples/src/test/java/jdocs/guide/ItemPopularityProjectionRepository.java
+++ b/examples/src/test/java/jdocs/guide/ItemPopularityProjectionRepository.java
@@ -39,8 +39,7 @@ class ItemPopularityProjectionRepositoryImpl implements ItemPopularityProjection
   @Override
   public CompletionStage<Done> update(String itemId, int delta) {
     return session.executeWrite(
-        String.format(
-            "UPDATE %s.%s SET count = count + ? WHERE item_id = ?", Keyspace, PopularityTable),
+        "UPDATE %s.%s SET count = count + ? WHERE item_id = ?".formatted(Keyspace, PopularityTable),
         (long) delta,
         itemId);
   }
@@ -49,8 +48,7 @@ class ItemPopularityProjectionRepositoryImpl implements ItemPopularityProjection
   public CompletionStage<Optional<Long>> getItem(String itemId) {
     return session
         .selectOne(
-            String.format(
-                "SELECT item_id, count FROM %s.%s WHERE item_id = ?", Keyspace, PopularityTable),
+            "SELECT item_id, count FROM %s.%s WHERE item_id = ?".formatted(Keyspace, PopularityTable),
             itemId)
         .thenApply(opt -> opt.map(row -> row.getLong("count")));
   }


### PR DESCRIPTION
## Summary
- Migrate `String.format("literal", args)` to `"literal".formatted(args)` (Java 15+ API)
- 1 file updated: Cassandra projection repository example
- Behavior-preserving refactoring, no functional changes

## Test plan
- [ ] Existing tests pass (behavior-preserving refactoring)
- [ ] `sbt javafmtAll` passes with JDK 17