### PR TITLE
refactor: use Map.copyOf (Java 10+)

### DIFF
--- a/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
+++ b/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
@@ -131,7 +131,7 @@ public class ShoppingCart
   public record Summary(Map<String, Integer> items, boolean checkedOut)
       implements CborSerializable {
     public Summary {
-      items = Collections.unmodifiableMap(new HashMap<>(items));
+      items = Map.copyOf(items);
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace `Collections.unmodifiableMap(new HashMap<>(items))` with `Map.copyOf(items)` in ShoppingCart.Summary record

## Changes
- `examples/src/test/java/jdocs/eventsourced/ShoppingCart.java`

## Notes
- `Map.copyOf()` rejects null keys/values, which is appropriate here since item IDs are validated strings and quantities are auto-boxed from `int` primitives
- Test/example code only, no API changes