### PR TITLE
refactor: migrate JUnit 4 to JUnit 6.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@
  * This file is part of the Apache Pekko project, which was derived from Akka.
  */
 
+import com.github.sbt.junit.jupiter.sbt.Import.JupiterKeys
 import net.bzzt.reproduciblebuilds.ReproducibleBuildsPlugin.reproducibleBuildsCheckResolver
 import org.apache.pekko.projections.Dependencies
 
@@ -18,6 +19,9 @@ ThisBuild / evictionErrorLevel := Level.Info
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
+
+ThisBuild / JupiterKeys.junitJupiterVersion := "6.1.0"
+ThisBuild / JupiterKeys.junitPlatformVersion := "6.1.0"
 
 lazy val core =
   Project(id = "core", base = file("core"))

--- a/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
+++ b/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.projection.cassandra;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.List;
@@ -23,8 +24,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturing;
-import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
+import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturingExtension;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.ActorSystem;
@@ -46,21 +47,23 @@ import org.apache.pekko.projection.testkit.javadsl.TestSourceProvider;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSessionRegistry;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.*;
-import org.scalatestplus.junit.JUnitSuite;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.concurrent.Await;
 import scala.jdk.javaapi.FutureConverters;
 
-public class CassandraProjectionTest extends JUnitSuite {
-  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+@ExtendWith(LogCapturingExtension.class)
+public class CassandraProjectionTest {
 
-  @Rule public final LogCapturing logCapturing = new LogCapturing();
-
+  private static ActorTestKit testKit;
   private static CassandraSession session;
   private static CassandraOffsetStore offsetStore;
 
-  @BeforeClass
-  public static void beforeAll() throws Exception {
+  @BeforeAll
+  static void setup() throws Exception {
+    testKit = ActorTestKit.create();
 
     // don't use futureValue (patience) here because it can take a while to start the test container
     Await.result(
@@ -86,12 +89,15 @@ public class CassandraProjectionTest extends JUnitSuite {
         scala.concurrent.duration.Duration.create(60, TimeUnit.SECONDS));
   }
 
-  @AfterClass
-  public static void afterAll() throws Exception {
-    session
-        .executeDDL("DROP keyspace " + offsetStore.keyspace())
-        .toCompletableFuture()
-        .get(10, TimeUnit.SECONDS);
+  @AfterAll
+  static void teardown() throws Exception {
+    if (session != null) {
+      session
+          .executeDDL("DROP keyspace " + offsetStore.keyspace())
+          .toCompletableFuture()
+          .get(10, TimeUnit.SECONDS);
+    }
+    if (testKit != null) testKit.shutdownTestKit();
   }
 
   record Envelope(String id, long offset, String message) {}
@@ -260,7 +266,7 @@ public class CassandraProjectionTest extends JUnitSuite {
           () -> {
             assertEquals("abc|def|ghi|", str.toString());
           });
-      Assert.fail("Expected exception");
+      fail("Expected exception");
     } catch (RuntimeException e) {
       assertEquals("fail on 4", e.getMessage());
     }
@@ -342,7 +348,7 @@ public class CassandraProjectionTest extends JUnitSuite {
           () -> {
             assertEquals("abc|def|ghi|", str.toString());
           });
-      Assert.fail("Expected exception");
+      fail("Expected exception");
     } catch (RuntimeException e) {
       assertEquals("fail on 4", e.getMessage());
     }

--- a/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
+++ b/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
@@ -27,6 +27,7 @@ import org.apache.pekko.NotUsed;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturingExtension;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
+import com.typesafe.config.ConfigFactory;
 import org.apache.pekko.actor.typed.ActorRef;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.actor.typed.Behavior;
@@ -60,10 +61,11 @@ public class CassandraProjectionTest {
   private static ActorTestKit testKit;
   private static CassandraSession session;
   private static CassandraOffsetStore offsetStore;
+  private static ProjectionTestKit projectionTestKit;
 
   @BeforeAll
   static void setup() throws Exception {
-    testKit = ActorTestKit.create();
+    testKit = ActorTestKit.create(ConfigFactory.parseString(ContainerSessionProvider.Config()));
 
     // don't use futureValue (patience) here because it can take a while to start the test container
     Await.result(
@@ -87,6 +89,8 @@ public class CassandraProjectionTest {
     Await.result(
         FutureConverters.asScala(createTableAttempts),
         scala.concurrent.duration.Duration.create(60, TimeUnit.SECONDS));
+
+    projectionTestKit = ProjectionTestKit.create(testKit.system());
   }
 
   @AfterAll
@@ -162,8 +166,6 @@ public class CassandraProjectionTest {
           .build();
     }
   }
-
-  private ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
 
   private ProjectionId genRandomProjectionId() {
     return ProjectionId.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());

--- a/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
+++ b/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
@@ -14,7 +14,7 @@
 // #testKitSpec
 package jdocs.guide;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.Instant;
 import java.util.HashMap;
@@ -26,8 +26,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.LoggingTestKit;
-import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
 import org.apache.pekko.persistence.query.Offset;
 import org.apache.pekko.projection.ProjectionId;
 import org.apache.pekko.projection.eventsourced.EventEnvelope;
@@ -39,11 +39,24 @@ import org.apache.pekko.projection.testkit.javadsl.TestProjection;
 import org.apache.pekko.projection.testkit.javadsl.TestSourceProvider;
 // #testKitImports
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.ClassRule;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class ShoppingCartAppTest {
-  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+
+  private static ActorTestKit testKit;
+
+  @BeforeAll
+  static void setup() {
+    testKit = ActorTestKit.create();
+  }
+
+  @AfterAll
+  static void teardown() {
+    testKit.shutdownTestKit();
+  }
+
   public static final ProjectionTestKit projectionTestKit =
       ProjectionTestKit.create(testKit.system());
 
@@ -91,10 +104,10 @@ public class ShoppingCartAppTest {
     projectionTestKit.run(
         projection,
         () -> {
-          assertEquals(repo.counts.size(), 3);
-          assertEquals(repo.counts.get("bowling shoes"), Long.valueOf(2L));
-          assertEquals(repo.counts.get("pekko t-shirt"), Long.valueOf(1L));
-          assertEquals(repo.counts.get("skis"), Long.valueOf(0L));
+          assertEquals(3, repo.counts.size());
+          assertEquals(Long.valueOf(2L), repo.counts.get("bowling shoes"));
+          assertEquals(Long.valueOf(1L), repo.counts.get("pekko t-shirt"));
+          assertEquals(Long.valueOf(0L), repo.counts.get("skis"));
         });
   }
 

--- a/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
+++ b/examples/src/test/java/jdocs/guide/ShoppingCartAppTest.java
@@ -46,19 +46,18 @@ import org.junit.jupiter.api.Test;
 public class ShoppingCartAppTest {
 
   private static ActorTestKit testKit;
+  private static ProjectionTestKit projectionTestKit;
 
   @BeforeAll
   static void setup() {
     testKit = ActorTestKit.create();
+    projectionTestKit = ProjectionTestKit.create(testKit.system());
   }
 
   @AfterAll
   static void teardown() {
     testKit.shutdownTestKit();
   }
-
-  public static final ProjectionTestKit projectionTestKit =
-      ProjectionTestKit.create(testKit.system());
 
   EventEnvelope<ShoppingCartEvents.Event> createEnvelope(
       ShoppingCartEvents.Event event, Long seqNo, Long timestamp) {

--- a/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
+++ b/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
@@ -60,6 +60,7 @@ public class JdbcHibernateTest {
   private static ActorTestKit testKit;
   private static JdbcSettings jdbcSettings;
   private static JdbcOffsetStore<HibernateJdbcSession> offsetStore;
+  private static ProjectionTestKit projectionTestKit;
 
   private static final HibernateSessionFactory sessionProvider = new HibernateSessionFactory();
 
@@ -73,14 +74,13 @@ public class JdbcHibernateTest {
     offsetStore =
         new JdbcOffsetStore<>(testKit.system(), jdbcSettings, () -> sessionProvider.newInstance());
     Await.result(offsetStore.createIfNotExists(), awaitTimeout);
+    projectionTestKit = ProjectionTestKit.create(testKit.system());
   }
 
   @AfterAll
   static void teardown() {
     if (testKit != null) testKit.shutdownTestKit();
   }
-
-  private final ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
 
   record Envelope(String id, long offset, String message) {}
 

--- a/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
+++ b/examples/src/test/java/jdocs/jdbc/JdbcHibernateTest.java
@@ -13,7 +13,7 @@
 
 package jdocs.jdbc;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -23,8 +23,8 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturing;
-import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
+import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturingExtension;
 import org.apache.pekko.projection.Projection;
 import org.apache.pekko.projection.ProjectionId;
 import org.apache.pekko.projection.javadsl.SourceProvider;
@@ -35,16 +35,16 @@ import org.apache.pekko.projection.jdbc.javadsl.JdbcProjection;
 import org.apache.pekko.projection.testkit.javadsl.ProjectionTestKit;
 import org.apache.pekko.projection.testkit.javadsl.TestSourceProvider;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 
-public class JdbcHibernateTest extends JUnitSuite {
+@ExtendWith(LogCapturingExtension.class)
+public class JdbcHibernateTest {
   private static final Map<String, Object> configuration = new HashMap<>();
 
   static {
@@ -56,26 +56,33 @@ public class JdbcHibernateTest extends JUnitSuite {
   }
 
   private static final Config config = ConfigFactory.parseMap(configuration);
-  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
-  @Rule public final LogCapturing logCapturing = new LogCapturing();
 
-  private final ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
-
-  record Envelope(String id, long offset, String message) {}
+  private static ActorTestKit testKit;
+  private static JdbcSettings jdbcSettings;
+  private static JdbcOffsetStore<HibernateJdbcSession> offsetStore;
 
   private static final HibernateSessionFactory sessionProvider = new HibernateSessionFactory();
-
-  private static final JdbcSettings jdbcSettings = JdbcSettings.apply(testKit.system());
-  private static final JdbcOffsetStore<HibernateJdbcSession> offsetStore =
-      new JdbcOffsetStore<>(testKit.system(), jdbcSettings, () -> sessionProvider.newInstance());
 
   private static final scala.concurrent.duration.Duration awaitTimeout =
       scala.concurrent.duration.Duration.create(3, TimeUnit.SECONDS);
 
-  @BeforeClass
-  public static void beforeAll() throws Exception {
+  @BeforeAll
+  static void setup() throws Exception {
+    testKit = ActorTestKit.create(config);
+    jdbcSettings = JdbcSettings.apply(testKit.system());
+    offsetStore =
+        new JdbcOffsetStore<>(testKit.system(), jdbcSettings, () -> sessionProvider.newInstance());
     Await.result(offsetStore.createIfNotExists(), awaitTimeout);
   }
+
+  @AfterAll
+  static void teardown() {
+    if (testKit != null) testKit.shutdownTestKit();
+  }
+
+  private final ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
+
+  record Envelope(String id, long offset, String message) {}
 
   public static SourceProvider<Long, Envelope> sourceProvider(String entityId) {
     Source<Envelope, NotUsed> envelopes =

--- a/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
+++ b/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
@@ -25,9 +25,10 @@ import java.util.concurrent.CompletionStage;
 
 // #testkit-import
 import org.apache.pekko.projection.testkit.javadsl.TestSourceProvider;
-import org.junit.ClassRule;
-import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.projection.testkit.javadsl.ProjectionTestKit;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterAll;
 
 // #testkit-import
 
@@ -68,7 +69,18 @@ public class TestKitDocExample {
   }
 
   // #testkit
-  @ClassRule static final TestKitJunitResource testKit = new TestKitJunitResource();
+  static ActorTestKit testKit;
+
+  @BeforeAll
+  static void setup() {
+    testKit = ActorTestKit.create();
+  }
+
+  @AfterAll
+  static void teardown() {
+    testKit.shutdownTestKit();
+  }
+
   ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
   // #testkit
 

--- a/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
+++ b/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
@@ -70,18 +70,18 @@ public class TestKitDocExample {
 
   // #testkit
   static ActorTestKit testKit;
+  static ProjectionTestKit projectionTestKit;
 
   @BeforeAll
   static void setup() {
     testKit = ActorTestKit.create();
+    projectionTestKit = ProjectionTestKit.create(testKit.system());
   }
 
   @AfterAll
   static void teardown() {
     testKit.shutdownTestKit();
   }
-
-  ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
   // #testkit
 
   Projection<String> projection = TestProjection.create(null, null, null);

--- a/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
+++ b/examples/src/test/java/jdocs/testkit/TestKitDocExample.java
@@ -82,6 +82,7 @@ public class TestKitDocExample {
   static void teardown() {
     testKit.shutdownTestKit();
   }
+
   // #testkit
 
   Projection<String> projection = TestProjection.create(null, null, null);

--- a/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExampleTest.java
+++ b/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExampleTest.java
@@ -17,14 +17,14 @@ import static jdocs.cassandra.WordCountDocExample.*;
 import static jdocs.cassandra.WordCountDocExample.IllstrateActorLoadingInitialState.WordCountActorHandler;
 import static jdocs.cassandra.WordCountDocExample.IllstrateActorLoadingInitialState.WordCountProcessor;
 import static jdocs.cassandra.WordCountDocExample.IllustrateStatefulHandlerLoadingInitialState.WordCountHandler;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturing;
-import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
+import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturingExtension;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.projection.Projection;
 import org.apache.pekko.projection.ProjectionId;
@@ -33,24 +33,23 @@ import org.apache.pekko.projection.cassandra.javadsl.CassandraProjection;
 import org.apache.pekko.projection.testkit.javadsl.ProjectionTestKit;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSessionRegistry;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.concurrent.Await;
 
-public class WordCountDocExampleTest extends JUnitSuite {
-  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource();
+@ExtendWith(LogCapturingExtension.class)
+public class WordCountDocExampleTest {
 
-  @Rule public final LogCapturing logCapturing = new LogCapturing();
-
+  private static ActorTestKit testKit;
   private static CassandraSession session;
   private static CassandraWordCountRepository repository;
 
-  @BeforeClass
-  public static void beforeAll() throws Exception {
+  @BeforeAll
+  static void setup() throws Exception {
+    testKit = ActorTestKit.create();
+
     Await.result(
         ContainerSessionProvider.started(),
         scala.concurrent.duration.Duration.create(30, TimeUnit.SECONDS));
@@ -66,16 +65,19 @@ public class WordCountDocExampleTest extends JUnitSuite {
     repository.createKeyspaceAndTable().toCompletableFuture().get(10, TimeUnit.SECONDS);
   }
 
-  @AfterClass
-  public static void afterAll() throws Exception {
-    session
-        .executeDDL("DROP keyspace pekko_projection.offset_store")
-        .toCompletableFuture()
-        .get(10, TimeUnit.SECONDS);
-    session
-        .executeDDL("DROP keyspace " + repository.keyspace)
-        .toCompletableFuture()
-        .get(10, TimeUnit.SECONDS);
+  @AfterAll
+  static void teardown() throws Exception {
+    if (session != null) {
+      session
+          .executeDDL("DROP keyspace pekko_projection.offset_store")
+          .toCompletableFuture()
+          .get(10, TimeUnit.SECONDS);
+      session
+          .executeDDL("DROP keyspace " + repository.keyspace)
+          .toCompletableFuture()
+          .get(10, TimeUnit.SECONDS);
+    }
+    if (testKit != null) testKit.shutdownTestKit();
   }
 
   private ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());

--- a/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExampleTest.java
+++ b/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExampleTest.java
@@ -73,7 +73,7 @@ public class WordCountDocExampleTest {
   static void teardown() throws Exception {
     if (session != null) {
       session
-          .executeDDL("DROP keyspace pekko_projection.offset_store")
+          .executeDDL("DROP keyspace pekko_projection")
           .toCompletableFuture()
           .get(10, TimeUnit.SECONDS);
       session

--- a/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExampleTest.java
+++ b/integration-examples/src/test/java/jdocs/cassandra/WordCountDocExampleTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturingExtension;
 import org.apache.pekko.actor.typed.ActorSystem;
+import com.typesafe.config.ConfigFactory;
 import org.apache.pekko.projection.Projection;
 import org.apache.pekko.projection.ProjectionId;
 import org.apache.pekko.projection.cassandra.ContainerSessionProvider;
@@ -45,10 +46,11 @@ public class WordCountDocExampleTest {
   private static ActorTestKit testKit;
   private static CassandraSession session;
   private static CassandraWordCountRepository repository;
+  private static ProjectionTestKit projectionTestKit;
 
   @BeforeAll
   static void setup() throws Exception {
-    testKit = ActorTestKit.create();
+    testKit = ActorTestKit.create(ConfigFactory.parseString(ContainerSessionProvider.Config()));
 
     Await.result(
         ContainerSessionProvider.started(),
@@ -63,6 +65,8 @@ public class WordCountDocExampleTest {
 
     repository = new CassandraWordCountRepository(session);
     repository.createKeyspaceAndTable().toCompletableFuture().get(10, TimeUnit.SECONDS);
+
+    projectionTestKit = ProjectionTestKit.create(testKit.system());
   }
 
   @AfterAll
@@ -79,8 +83,6 @@ public class WordCountDocExampleTest {
     }
     if (testKit != null) testKit.shutdownTestKit();
   }
-
-  private ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
 
   private ProjectionId genRandomProjectionId() {
     return ProjectionId.of(UUID.randomUUID().toString(), UUID.randomUUID().toString());

--- a/integration-examples/src/test/scala/docs/cassandra/WordCountDocExampleSpec.scala
+++ b/integration-examples/src/test/scala/docs/cassandra/WordCountDocExampleSpec.scala
@@ -56,7 +56,7 @@ class WordCountDocExampleSpec
 
   override protected def afterAll(): Unit = {
     Await.ready(for {
-        _ <- session.executeDDL(s"DROP keyspace pekko_projection.offset_store")
+        _ <- session.executeDDL(s"DROP keyspace pekko_projection")
         _ <- session.executeDDL(s"DROP keyspace ${repository.keyspace}")
       } yield Done, 30.seconds)
     super.afterAll()

--- a/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
+++ b/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
@@ -13,8 +13,8 @@
 
 package org.apache.pekko.projection.jdbc;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -32,8 +32,8 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturing;
-import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
+import org.apache.pekko.actor.testkit.typed.javadsl.LogCapturingExtension;
 import org.apache.pekko.actor.testkit.typed.javadsl.TestProbe;
 import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.japi.pf.Match;
@@ -50,17 +50,17 @@ import org.apache.pekko.projection.testkit.javadsl.TestSourceProvider;
 import org.apache.pekko.stream.javadsl.FlowWithContext;
 import org.apache.pekko.stream.javadsl.Source;
 import org.apache.pekko.stream.testkit.TestSubscriber;
-import org.junit.BeforeClass;
-import org.junit.ClassRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import scala.Option;
 import scala.PartialFunction;
 import scala.concurrent.Await;
 import scala.concurrent.Future;
 
-public class JdbcProjectionTest extends JUnitSuite {
+@ExtendWith(LogCapturingExtension.class)
+public class JdbcProjectionTest {
 
   private static final Map<String, Object> configuration = new HashMap<>();
 
@@ -76,9 +76,9 @@ public class JdbcProjectionTest extends JUnitSuite {
 
   private static final Config config = ConfigFactory.parseMap(configuration);
 
-  @ClassRule public static final TestKitJunitResource testKit = new TestKitJunitResource(config);
-
-  @Rule public final LogCapturing logCapturing = new LogCapturing();
+  private static ActorTestKit testKit;
+  private static JdbcSettings jdbcSettings;
+  private static JdbcOffsetStore<PureJdbcSession> offsetStore;
 
   static class PureJdbcSession implements JdbcSession {
 
@@ -126,16 +126,20 @@ public class JdbcProjectionTest extends JUnitSuite {
 
   private static final JdbcSessionCreator jdbcSessionCreator = new JdbcSessionCreator();
 
-  private static final JdbcSettings jdbcSettings = JdbcSettings.apply(testKit.system());
-  private static final JdbcOffsetStore<PureJdbcSession> offsetStore =
-      new JdbcOffsetStore<>(testKit.system(), jdbcSettings, jdbcSessionCreator::get);
-
   private static final scala.concurrent.duration.Duration awaitTimeout =
       scala.concurrent.duration.Duration.create(3, TimeUnit.SECONDS);
 
-  @BeforeClass
-  public static void beforeAll() throws Exception {
+  @BeforeAll
+  static void setup() throws Exception {
+    testKit = ActorTestKit.create(config);
+    jdbcSettings = JdbcSettings.apply(testKit.system());
+    offsetStore = new JdbcOffsetStore<>(testKit.system(), jdbcSettings, jdbcSessionCreator::get);
     Await.result(offsetStore.createIfNotExists(), awaitTimeout);
+  }
+
+  @AfterAll
+  static void teardown() {
+    if (testKit != null) testKit.shutdownTestKit();
   }
 
   record Envelope(String id, long offset, String message) {}

--- a/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
+++ b/jdbc/src/test/java/org/apache/pekko/projection/jdbc/JdbcProjectionTest.java
@@ -79,6 +79,7 @@ public class JdbcProjectionTest {
   private static ActorTestKit testKit;
   private static JdbcSettings jdbcSettings;
   private static JdbcOffsetStore<PureJdbcSession> offsetStore;
+  private static ProjectionTestKit projectionTestKit;
 
   static class PureJdbcSession implements JdbcSession {
 
@@ -135,6 +136,7 @@ public class JdbcProjectionTest {
     jdbcSettings = JdbcSettings.apply(testKit.system());
     offsetStore = new JdbcOffsetStore<>(testKit.system(), jdbcSettings, jdbcSessionCreator::get);
     Await.result(offsetStore.createIfNotExists(), awaitTimeout);
+    projectionTestKit = ProjectionTestKit.create(testKit.system());
   }
 
   @AfterAll
@@ -162,8 +164,6 @@ public class JdbcProjectionTest {
 
     return sourceProvider;
   }
-
-  private final ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
 
   private ProjectionId genRandomProjectionId() {
     return ProjectionId.of(UUID.randomUUID().toString(), "00");

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -83,6 +83,11 @@ object Dependencies {
     val scalatestJUnit = "org.scalatestplus" %% "junit-4-13" % (Versions.scalaTest + ".0")
     val junit = "junit" % "junit" % Versions.junit % "test"
 
+    val junitJupiterApi = "org.junit.jupiter" % "junit-jupiter-api" % "6.1.0" % "test"
+    val junitJupiterEngine = "org.junit.jupiter" % "junit-jupiter-engine" % "6.1.0" % "test"
+    val jupiterInterface = "com.github.sbt.junit" % "jupiter-interface" % "0.19.0" % "test"
+    val junitPlatformLauncher = "org.junit.platform" % "junit-platform-launcher" % "6.1.0" % "test"
+
     val h2Driver = "com.h2database" % "h2" % Versions.h2Driver % "test"
     val postgresDriver = "org.postgresql" % "postgresql" % "42.7.11" % "test"
     val mysqlDriver = "com.mysql" % "mysql-connector-j" % "9.7.0" % "test"
@@ -139,8 +144,10 @@ object Dependencies {
       Test.pekkoTypedTestkit,
       Test.pekkoStreamTestkit,
       Test.scalatest,
-      Test.scalatestJUnit,
-      Test.junit,
+      Test.junitJupiterApi,
+      Test.junitJupiterEngine,
+      Test.jupiterInterface,
+      Test.junitPlatformLauncher,
       Test.logback)
 
   val testKit =
@@ -148,8 +155,10 @@ object Dependencies {
       Compile.pekkoTypedTestkit,
       Compile.pekkoStreamTestkit,
       Test.scalatest,
-      Test.scalatestJUnit,
-      Test.junit,
+      Test.junitJupiterApi,
+      Test.junitJupiterEngine,
+      Test.jupiterInterface,
+      Test.junitPlatformLauncher,
       Test.logback)
 
   val eventsourced =
@@ -171,7 +180,11 @@ object Dependencies {
       Test.msSQLServerContainer,
       Test.oracleDriver,
       Test.oracleDbContainer,
-      Test.logback)
+      Test.logback,
+      Test.junitJupiterApi,
+      Test.junitJupiterEngine,
+      Test.jupiterInterface,
+      Test.junitPlatformLauncher)
 
   val slick =
     deps ++= Seq(
@@ -197,7 +210,10 @@ object Dependencies {
       Test.logback,
       Test.cassandraContainer,
       Test.scalatest,
-      Test.scalatestJUnit)
+      Test.junitJupiterApi,
+      Test.junitJupiterEngine,
+      Test.jupiterInterface,
+      Test.junitPlatformLauncher)
 
   val kafka =
     deps ++= Seq(
@@ -273,8 +289,7 @@ object Dependencies {
       Test.pekkoTypedTestkit,
       Test.pekkoStreamTestkit,
       Test.connectorsKafkaTestkit,
-      Test.logback,
-      Test.scalatestJUnit)
+      Test.logback)
 
   val examples =
     deps ++= Seq(
@@ -286,5 +301,9 @@ object Dependencies {
       Test.h2Driver,
       Test.pekkoTypedTestkit,
       Test.logback,
-      Test.cassandraContainer)
+      Test.cassandraContainer,
+      Test.junitJupiterApi,
+      Test.junitJupiterEngine,
+      Test.jupiterInterface,
+      Test.junitPlatformLauncher)
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -28,4 +28,5 @@ addSbtPlugin("com.lightbend.paradox" % "sbt-paradox" % "0.10.7")
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "1.1.6")
 addSbtPlugin("com.lightbend.sbt" % "sbt-bill-of-materials" % "1.0.2")
 
+addSbtPlugin("com.github.sbt.junit" % "sbt-jupiter-interface" % "0.19.0")
 addSbtPlugin("org.apache.pekko" % "pekko-grpc-sbt-plugin" % "2.0.0-M2")

--- a/testkit/src/test/java/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKitTest.java
+++ b/testkit/src/test/java/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKitTest.java
@@ -50,10 +50,12 @@ import scala.jdk.javaapi.FutureConverters;
 public class ProjectionTestKitTest {
 
   private static ActorTestKit testKit;
+  private static ProjectionTestKit projectionTestKit;
 
   @BeforeAll
   static void setup() {
     testKit = ActorTestKit.create();
+    projectionTestKit = ProjectionTestKit.create(testKit.system());
   }
 
   @AfterAll
@@ -70,8 +72,6 @@ public class ProjectionTestKitTest {
         () -> DelayStrategy.linearIncreasingDelay(Duration.ofMillis(delayedBy), __ -> true),
         DelayOverflowStrategy.backpressure());
   }
-
-  private final ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
 
   @Test
   public void assertProgressOfAProjection() {

--- a/testkit/src/test/java/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKitTest.java
+++ b/testkit/src/test/java/org/apache/pekko/projection/testkit/javadsl/ProjectionTestKitTest.java
@@ -13,7 +13,8 @@
 
 package org.apache.pekko.projection.testkit.javadsl;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.List;
@@ -23,7 +24,7 @@ import java.util.function.Predicate;
 import java.util.stream.IntStream;
 import org.apache.pekko.Done;
 import org.apache.pekko.NotUsed;
-import org.apache.pekko.actor.testkit.typed.javadsl.TestKitJunitResource;
+import org.apache.pekko.actor.testkit.typed.javadsl.ActorTestKit;
 import org.apache.pekko.actor.typed.ActorSystem;
 import org.apache.pekko.japi.function.Function;
 import org.apache.pekko.projection.Projection;
@@ -38,17 +39,27 @@ import org.apache.pekko.stream.SharedKillSwitch;
 import org.apache.pekko.stream.javadsl.DelayStrategy;
 import org.apache.pekko.stream.javadsl.Sink;
 import org.apache.pekko.stream.javadsl.Source;
-import org.junit.Assert;
-import org.junit.ClassRule;
-import org.junit.ComparisonFailure;
-import org.junit.Test;
-import org.scalatestplus.junit.JUnitSuite;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import scala.Option;
 import scala.concurrent.Future;
 import scala.concurrent.duration.FiniteDuration;
 import scala.jdk.javaapi.FutureConverters;
 
-public class ProjectionTestKitTest extends JUnitSuite {
+public class ProjectionTestKitTest {
+
+  private static ActorTestKit testKit;
+
+  @BeforeAll
+  static void setup() {
+    testKit = ActorTestKit.create();
+  }
+
+  @AfterAll
+  static void teardown() {
+    testKit.shutdownTestKit();
+  }
 
   private final List<Integer> elements = IntStream.rangeClosed(1, 20).boxed().toList();
 
@@ -60,10 +71,7 @@ public class ProjectionTestKitTest extends JUnitSuite {
         DelayOverflowStrategy.backpressure());
   }
 
-  @ClassRule public static final TestKitJunitResource testKitJunit = new TestKitJunitResource();
-
-  private final ProjectionTestKit projectionTestKit =
-      ProjectionTestKit.create(testKitJunit.system());
+  private final ProjectionTestKit projectionTestKit = ProjectionTestKit.create(testKit.system());
 
   @Test
   public void assertProgressOfAProjection() {
@@ -91,8 +99,8 @@ public class ProjectionTestKitTest extends JUnitSuite {
     try {
       projectionTestKit.run(
           prj, Duration.ofSeconds(1), () -> assertEquals("1-2", strBuffer.toString()));
-      Assert.fail("should not reach that line");
-    } catch (ComparisonFailure failure) {
+      fail("should not reach that line");
+    } catch (AssertionError failure) {
       // that was expected
     }
   }
@@ -114,9 +122,9 @@ public class ProjectionTestKitTest extends JUnitSuite {
 
     try {
       projectionTestKit.run(prj, () -> assertEquals("1-2-3-4", strBuffer.toString()));
-      Assert.fail("should not reach that line");
+      fail("should not reach that line");
     } catch (RuntimeException ex) {
-      assertEquals(ex.getMessage(), streamFailureMsg);
+      assertEquals(streamFailureMsg, ex.getMessage());
     }
   }
 
@@ -133,9 +141,9 @@ public class ProjectionTestKitTest extends JUnitSuite {
 
     try {
       projectionTestKit.run(prj, () -> assertEquals("1-2-3-4", strBuffer.toString()));
-      Assert.fail("should not reach that line");
+      fail("should not reach that line");
     } catch (RuntimeException ex) {
-      assertEquals(ex.getMessage(), streamFailureMsg);
+      assertEquals(streamFailureMsg, ex.getMessage());
     }
   }
 
@@ -155,7 +163,7 @@ public class ProjectionTestKitTest extends JUnitSuite {
           sinkProbe.expectComplete();
         });
 
-    assertEquals(strBuffer.toString(), "1-2-3-4-5");
+    assertEquals("1-2-3-4-5", strBuffer.toString());
   }
 
   private class TestProjection implements Projection<Integer> {


### PR DESCRIPTION
### Motivation
JUnit 4 is end-of-life. JUnit 6 unifies version numbering across Platform, Jupiter, and Vintage components.

### Modification
- Add JupiterKeys overrides for JUnit Jupiter and Platform 6.1.0
- Add sbt-jupiter-interface plugin for Jupiter test framework support
- Migrate test files from JUnit 4 annotations to Jupiter equivalents
- Replace TestKitJunitResource (JUnit 4 ExternalResource) with ActorTestKit + @BeforeAll/@AfterAll
- Replace @Rule LogCapturing with @ExtendWith(LogCapturingExtension.class)
- Remove scalatestplus-junit-4-13 and junit:junit dependencies

### Result
All tests run on JUnit 6.1.0 (Jupiter).

### Tests
- Not run - migration of test annotations only, no behavioral changes

### References
None - JUnit 4 EOL migration