### PR TITLE
fix: fix javadoc warning in ShoppingCart test example

### DIFF
--- a/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
+++ b/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
@@ -122,8 +122,8 @@ public class ShoppingCart
   /**
    * A command to checkout the shopping cart.
    *
-   * <p>The reply type is the {@link ShoppingCart.Confirmation}, which will be returned when the events have been
-   * emitted.
+   * <p>The reply type is the {@link ShoppingCart.Confirmation}, which will be returned when the
+   * events have been emitted.
    */
   public record Checkout(ActorRef<Confirmation> replyTo) implements Command {}
 

--- a/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
+++ b/examples/src/test/java/jdocs/eventsourced/ShoppingCart.java
@@ -115,14 +115,14 @@ public class ShoppingCart
   /**
    * A command to get the current state of the shopping cart.
    *
-   * <p>The reply type is the {@link Summary}
+   * <p>The reply type is the {@link ShoppingCart.Summary}
    */
   public record Get(ActorRef<Summary> replyTo) implements Command {}
 
   /**
    * A command to checkout the shopping cart.
    *
-   * <p>The reply type is the {@link Confirmation}, which will be returned when the events have been
+   * <p>The reply type is the {@link ShoppingCart.Confirmation}, which will be returned when the events have been
    * emitted.
    */
   public record Checkout(ActorRef<Confirmation> replyTo) implements Command {}


### PR DESCRIPTION
## Motivation

Javadoc warning in `examples/src/test/java/jdocs/eventsourced/ShoppingCart.java`:
- `{@link Summary}` and `{@link Confirmation}` cannot be resolved because they are inner classes of `ShoppingCart` and need the enclosing class prefix

## Modification

- Replace `{@link Summary}` with `{@link ShoppingCart.Summary}`
- Replace `{@link Confirmation}` with `{@link ShoppingCart.Confirmation}`

## Result

Javadoc warning is eliminated.

## Tests

Not run - docs only

## References

None