### PR TITLE
fix: fix scaladoc warnings

### DIFF
--- a/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/javadsl/CassandraProjection.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/javadsl/CassandraProjection.scala
@@ -54,7 +54,7 @@ object CassandraProjection {
    * from previously stored offset some elements may be processed more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceCassandraProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -74,7 +74,7 @@ object CassandraProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedCassandraProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
@@ -97,7 +97,7 @@ object CassandraProjection {
       statusObserver = NoopStatusObserver)
 
   /**
-   * Create a [[pekko.projection.Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once processing
+   * Create a [[pekko.projection.Projection]] with a `FlowWithContext` as the envelope handler. It has at-least-once processing
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried

--- a/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/scaladsl/CassandraProjection.scala
+++ b/cassandra/src/main/scala/org/apache/pekko/projection/cassandra/scaladsl/CassandraProjection.scala
@@ -57,7 +57,7 @@ object CassandraProjection {
    * from previously stored offset some envelopes may be processed more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceCassandraProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -77,7 +77,7 @@ object CassandraProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedCassandraProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
@@ -99,7 +99,7 @@ object CassandraProjection {
       statusObserver = NoopStatusObserver)
 
   /**
-   * Create a [[pekko.projection.Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once processing
+   * Create a [[pekko.projection.Projection]] with a `FlowWithContext` as the envelope handler. It has at-least-once processing
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried

--- a/core/src/main/scala/org/apache/pekko/projection/Projection.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/Projection.scala
@@ -31,7 +31,7 @@ import pekko.stream.scaladsl.Source
 /**
  * The core abstraction in Pekko Projections.
  *
- * A projection instance may share the same name and [[Envelope]], but must have a unique key. The key is used
+ * A projection instance may share the same name and `Envelope`, but must have a unique key. The key is used
  * to achieve processing parallelism for a projection.
  *
  * For example, many projections may share the same name "user-events-projection", but can process events for

--- a/core/src/main/scala/org/apache/pekko/projection/ProjectionId.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/ProjectionId.scala
@@ -72,7 +72,7 @@ object ProjectionId {
    *
    * @param name - the projection name
    * @param keys  - the Set of keys to associated with the passed name.
-   * @return an [[immutable.Set]] of [[ProjectionId]]s
+   * @return an `immutable.Set` of [[ProjectionId]]s
    */
   def apply(name: String, keys: immutable.Set[String]): immutable.Set[ProjectionId] =
     keys.map(key => new ProjectionId(name, key))

--- a/core/src/main/scala/org/apache/pekko/projection/internal/Telemetry.scala
+++ b/core/src/main/scala/org/apache/pekko/projection/internal/Telemetry.scala
@@ -29,7 +29,7 @@ import pekko.projection.ProjectionId
  * Service Provider Interface (SPI) for collecting metrics from projections.
  *
  * Implementations must include a single constructor with two arguments: [[ProjectionId]]
- * and [[ActorSystem]].  To setup your implementation, add a setting on your `application.conf`:
+ * and `ActorSystem`.  To setup your implementation, add a setting on your `application.conf`:
  *
  * {{{
  * pekko.projection.telemetry.implementations += com.example.MyMetrics

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/consumer/scaladsl/GrpcReadJournal.scala
@@ -237,7 +237,7 @@ final class GrpcReadJournal private (
    * The consumer can keep track of its current position in the event stream by storing the `offset` and restart the
    * query from a given `offset` after a crash/restart.
    *
-   * The supported offset is [[TimestampOffset]] and [[Offset.noOffset]].
+   * The supported offset is `TimestampOffset` and `Offset.noOffset`.
    *
    * The timestamp is based on the database `transaction_timestamp()` when the event was stored.
    * `transaction_timestamp()` is the time when the transaction started, not when it was committed. This means that a

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/ReplicatedBehaviors.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/ReplicatedBehaviors.scala
@@ -23,7 +23,7 @@ import pekko.persistence.typed.javadsl.ReplicationContext
 /**
  * Dynamically provides factory methods for creating replicated event sourced behaviors.
  *
- * Must be used to create an event sourced behavior to be replicated with [[Replication.grpcReplication]].
+ * Must be used to create an event sourced behavior to be replicated with `Replication.grpcReplication`.
  *
  * Can optionally be composed with other Behavior factories, to get access to actor context or timers.
  */

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/Replication.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/javadsl/Replication.scala
@@ -39,7 +39,7 @@ import java.util.function.Predicate
 import pekko.persistence.query.typed.EventEnvelope
 
 /**
- * Created using [[Replication.grpcReplication]], which starts sharding with the entity and
+ * Created using `Replication.grpcReplication`, which starts sharding with the entity and
  * replication stream consumers but not the replication endpoint needed to publish events to other replication places.
  *
  * @tparam Command The type of commands the Replicated Event Sourced Entity accepts

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ReplicatedBehaviors.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/ReplicatedBehaviors.scala
@@ -22,7 +22,7 @@ import pekko.persistence.typed.scaladsl.ReplicationContext
 /**
  * Dynamically provides factory methods for creating replicated event sourced behaviors.
  *
- * Must be used to create an event sourced behavior to be replicated with [[Replication.grpcReplication]].
+ * Must be used to create an event sourced behavior to be replicated with `Replication.grpcReplication`.
  *
  * Can optionally be composed with other Behavior factories, to get access to actor context or timers.
  */

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/Replication.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/replication/scaladsl/Replication.scala
@@ -33,7 +33,7 @@ import scala.concurrent.Future
 import pekko.persistence.query.typed.EventEnvelope
 
 /**
- * Created using [[Replication.grpcReplication]], which starts sharding with the entity and
+ * Created using `Replication.grpcReplication`, which starts sharding with the entity and
  * replication stream consumers but not the replication endpoint needed to publish events to other replication places.
  *
  * @tparam Command The type of commands the Replicated Event Sourced Entity accepts

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/JdbcSession.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/JdbcSession.scala
@@ -30,7 +30,7 @@ import pekko.japi.function.{ Function => JFunction }
  * the transaction. It's paramount to configure the connection to NOT use `auto-commit` in order to guarantee that the
  * event handling and offset persistence operations participate on the same transaction.
  *
- * The only requirement to implement a [[JdbcSession]] is to have access to the underlying JDBC [[Connection]].
+ * The only requirement to implement a [[JdbcSession]] is to have access to the underlying JDBC `Connection`.
  * When using plain JDBC, one can initialize a connection directly, but when relying on a JDBC framework like JPA it will depend on the
  * chosen implementation. Hibernate for instance provides indirect access to the underlying connection through a
  * lambda call and therefore can be used (see [[JdbcSession#withConnection]] method). Other JPA implementations may not provide this feature.
@@ -50,7 +50,7 @@ trait JdbcSession {
 
   /**
    * Commits the transaction after processing.
-   * Should delegate to [[Connection#commit()]] or equivalent depending on underlying JDBC framework.
+   * Should delegate to `Connection#commit()` or equivalent depending on underlying JDBC framework.
    *
    * @throws java.sql.SQLException
    */
@@ -59,7 +59,7 @@ trait JdbcSession {
 
   /**
    * Rollback the transaction in case of failures.
-   * Should delegate to [[Connection#rollback()]] or equivalent depending on underlying JDBC framework.
+   * Should delegate to `Connection#rollback()` or equivalent depending on underlying JDBC framework.
    *
    * @throws java.sql.SQLException
    */
@@ -68,7 +68,7 @@ trait JdbcSession {
 
   /**
    * Closes the connection after use.
-   * Should delegate to [[Connection#close()]] or equivalent depending on underlying JDBC framework.
+   * Should delegate to `Connection#close()` or equivalent depending on underlying JDBC framework.
    *
    * @throws java.sql.SQLException
    */

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/javadsl/JdbcProjection.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/javadsl/JdbcProjection.scala
@@ -93,7 +93,7 @@ object JdbcProjection {
    * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -128,7 +128,7 @@ object JdbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] with at-least-once processing semantics.
    *
-   * Compared to [[JdbcProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in the
+   * Compared to [[JdbcProjection.atLeastOnce]] the `Handler` is not storing the projected result in the
    * database, but is integrating with something else.
    *
    * It stores the offset in a relational database table using JDBC after the `handler` has processed the envelope.
@@ -136,7 +136,7 @@ object JdbcProjection {
    * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -165,7 +165,7 @@ object JdbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
@@ -206,11 +206,11 @@ object JdbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
-   * Compared to [[JdbcProjection.groupedWithin]] the [[Handler]] is not storing the projected result in the
+   * Compared to [[JdbcProjection.groupedWithin]] the `Handler` is not storing the projected result in the
    * database, but is integrating with something else.
    *
    * It stores the offset in  a relational database table using JDBC immediately after the `handler` has
@@ -242,7 +242,7 @@ object JdbcProjection {
   }
 
   /**
-   * Create a [[pekko.projection.Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once processing
+   * Create a [[pekko.projection.Projection]] with a `FlowWithContext` as the envelope handler. It has at-least-once processing
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried

--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/scaladsl/JdbcProjection.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/scaladsl/JdbcProjection.scala
@@ -84,12 +84,12 @@ object JdbcProjection {
    * This means that if the projection is restarted from previously stored offset then some elements may be processed
    * more than once.
    *
-   * The [[JdbcHandler.process()]] in [[handler]] will be wrapped in a transaction. It is highly recommended to use
-   * a [[sessionFactory]] that provides [[java.sql.Connection]]'s with [[setAutoCommit(false)]]. The transaction
-   * will be committed after invoking [[JdbcHandler.process()]].
+   * The `JdbcHandler.process()` in `handler` will be wrapped in a transaction. It is highly recommended to use
+   * a `sessionFactory` that provides `java.sql.Connection`'s with `setAutoCommit(false)`. The transaction
+   * will be committed after invoking `JdbcHandler.process()`.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -120,7 +120,7 @@ object JdbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] with at-least-once processing semantics.
    *
-   * Compared to [[JdbcProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in the
+   * Compared to [[JdbcProjection.atLeastOnce]] the `Handler` is not storing the projected result in the
    * database, but is integrating with something else.
    *
    * It stores the offset in a relational database table using JDBC after the `handler` has processed the envelope.
@@ -128,7 +128,7 @@ object JdbcProjection {
    * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -155,7 +155,7 @@ object JdbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
@@ -189,11 +189,11 @@ object JdbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
-   * Compared to [[JdbcProjection.groupedWithin]] the [[Handler]] is not storing the projected result in the
+   * Compared to [[JdbcProjection.groupedWithin]] the `Handler` is not storing the projected result in the
    * database, but is integrating with something else.
    *
    * It stores the offset in  a relational database table using JDBC immediately after the `handler` has
@@ -223,7 +223,7 @@ object JdbcProjection {
   }
 
   /**
-   * Create a [[pekko.projection.Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once processing
+   * Create a [[pekko.projection.Projection]] with a `FlowWithContext` as the envelope handler. It has at-least-once processing
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/javadsl/KafkaSourceProvider.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/javadsl/KafkaSourceProvider.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 object KafkaSourceProvider {
 
   /**
-   * Create a [[SourceProvider]] that resumes from externally managed offsets
+   * Create a `SourceProvider` that resumes from externally managed offsets
    */
   def create[K, V](
       system: ActorSystem[?],

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/scaladsl/KafkaSourceProvider.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/scaladsl/KafkaSourceProvider.scala
@@ -30,7 +30,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord
 object KafkaSourceProvider {
 
   /**
-   * Create a [[SourceProvider]] that resumes from externally managed offsets
+   * Create a `SourceProvider` that resumes from externally managed offsets
    */
   def apply[K, V](
       system: ActorSystem[?],

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcProjection.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/javadsl/R2dbcProjection.scala
@@ -76,7 +76,7 @@ object R2dbcProjection {
    * invoking [[R2dbcHandler.process]].
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first. This window
-   * can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned `AtLeastOnceProjection`. The default
+   * can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned `AtLeastOnceProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.at-least-once`.
    */
   def atLeastOnce[Offset, Envelope](
@@ -97,7 +97,7 @@ object R2dbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] with at-least-once processing semantics.
    *
-   * Compared to [[R2dbcProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in the database,
+   * Compared to [[R2dbcProjection.atLeastOnce]] the `Handler` is not storing the projected result in the database,
    * but is integrating with something else.
    *
    * It stores the offset in a relational database table using R2DBC after the `handler` has processed the envelope.
@@ -105,7 +105,7 @@ object R2dbcProjection {
    * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first. This window
-   * can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned `AtLeastOnceProjection`. The default
+   * can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned `AtLeastOnceProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.at-least-once`.
    */
   def atLeastOnceAsync[Offset, Envelope](
@@ -127,7 +127,7 @@ object R2dbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes, whatever happens first. This
-   * window can be defined with [[GroupedProjection.withGroup]] of the returned `GroupedProjection`. The default
+   * window can be defined with `GroupedProjection.withGroup` of the returned `GroupedProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.grouped`.
    *
    * It stores the offset in a relational database table using R2DBC in the same transaction as the user defined
@@ -151,10 +151,10 @@ object R2dbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes, whatever happens first. This
-   * window can be defined with [[GroupedProjection.withGroup]] of the returned `GroupedProjection`. The default
+   * window can be defined with `GroupedProjection.withGroup` of the returned `GroupedProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.grouped`.
    *
-   * Compared to [[R2dbcProjection.groupedWithin]] the [[Handler]] is not storing the projected result in the database,
+   * Compared to [[R2dbcProjection.groupedWithin]] the `Handler` is not storing the projected result in the database,
    * but is integrating with something else.
    *
    * It stores the offset in a relational database table using R2DBC immediately after the `handler` has processed the
@@ -177,7 +177,7 @@ object R2dbcProjection {
   }
 
   /**
-   * Create a [[pekko.projection.Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once
+   * Create a [[pekko.projection.Projection]] with a `FlowWithContext` as the envelope handler. It has at-least-once
    * processing semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried in the

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcProjection.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/scaladsl/R2dbcProjection.scala
@@ -105,11 +105,11 @@ object R2dbcProjection {
    * This means that if the projection is restarted from previously stored offset then some elements may be processed
    * more than once.
    *
-   * The [[R2dbcHandler.process()]] in `handler` will be wrapped in a transaction. The transaction will be committed
-   * after invoking [[R2dbcHandler.process()]].
+   * The `R2dbcHandler.process()` in `handler` will be wrapped in a transaction. The transaction will be committed
+   * after invoking `R2dbcHandler.process()`.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first. This window
-   * can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned `AtLeastOnceProjection`. The default
+   * can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned `AtLeastOnceProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.at-least-once`.
    */
   def atLeastOnce[Offset, Envelope](
@@ -161,7 +161,7 @@ object R2dbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] with at-least-once processing semantics.
    *
-   * Compared to [[R2dbcProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in the database,
+   * Compared to `R2dbcProjection.atLeastOnce` the `Handler` is not storing the projected result in the database,
    * but is integrating with something else.
    *
    * It stores the offset in a relational database table using R2DBC after the `handler` has processed the envelope.
@@ -169,7 +169,7 @@ object R2dbcProjection {
    * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first. This window
-   * can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned `AtLeastOnceProjection`. The default
+   * can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned `AtLeastOnceProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.at-least-once`.
    */
   def atLeastOnceAsync[Offset, Envelope](
@@ -216,7 +216,7 @@ object R2dbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes, whatever happens first. This
-   * window can be defined with [[GroupedProjection.withGroup]] of the returned `GroupedProjection`. The default
+   * window can be defined with `GroupedProjection.withGroup` of the returned `GroupedProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.grouped`.
    *
    * It stores the offset in a relational database table using R2DBC in the same transaction as the user defined
@@ -271,10 +271,10 @@ object R2dbcProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes, whatever happens first. This
-   * window can be defined with [[GroupedProjection.withGroup]] of the returned `GroupedProjection`. The default
+   * window can be defined with `GroupedProjection.withGroup` of the returned `GroupedProjection`. The default
    * settings for the window is defined in configuration section `pekko.projection.grouped`.
    *
-   * Compared to [[R2dbcProjection.groupedWithin]] the [[Handler]] is not storing the projected result in the database,
+   * Compared to `R2dbcProjection.groupedWithin` the `Handler` is not storing the projected result in the database,
    * but is integrating with something else.
    *
    * It stores the offset in a relational database table using R2DBC immediately after the `handler` has processed the
@@ -325,7 +325,7 @@ object R2dbcProjection {
   }
 
   /**
-   * Create a [[pekko.projection.Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once
+   * Create a [[pekko.projection.Projection]] with a `FlowWithContext` as the envelope handler. It has at-least-once
    * processing semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried in the

--- a/slick/src/main/scala/org/apache/pekko/projection/slick/SlickProjection.scala
+++ b/slick/src/main/scala/org/apache/pekko/projection/slick/SlickProjection.scala
@@ -133,7 +133,7 @@ object SlickProjection {
   /**
    * Create a [[pekko.projection.Projection]] with at-least-once processing semantics.
    *
-   * The DBIO returned by the [[SlickHandler.process()]] of the provided [[handler]] will be
+   * The DBIO returned by the `SlickHandler.process()` of the provided `handler` will be
    * wrapped in a transaction.
    *
    * It stores the offset in a relational database table using Slick after the `handler` has processed the envelope.
@@ -141,7 +141,7 @@ object SlickProjection {
    * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -183,7 +183,7 @@ object SlickProjection {
   /**
    * Create a [[pekko.projection.Projection]] with at-least-once processing semantics.
    *
-   * Compared to [[SlickProjection.atLeastOnce]] the [[Handler]] is not storing the projected result in the
+   * Compared to [[SlickProjection.atLeastOnce]] the `Handler` is not storing the projected result in the
    * database, but is integrating with something else.
    *
    * It stores the offset in a relational database table using Slick after the `handler` has processed the envelope.
@@ -191,7 +191,7 @@ object SlickProjection {
    * more than once.
    *
    * The offset is stored after a time window, or limited by a number of envelopes, whatever happens first.
-   * This window can be defined with [[AtLeastOnceProjection.withSaveOffset]] of the returned
+   * This window can be defined with `AtLeastOnceProjection.withSaveOffset` of the returned
    * `AtLeastOnceProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.at-least-once`.
    */
@@ -216,7 +216,7 @@ object SlickProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
@@ -292,11 +292,11 @@ object SlickProjection {
   /**
    * Create a [[pekko.projection.Projection]] that groups envelopes and calls the `handler` with a group of `Envelopes`.
    * The envelopes are grouped within a time window, or limited by a number of envelopes,
-   * whatever happens first. This window can be defined with [[GroupedProjection.withGroup]] of
+   * whatever happens first. This window can be defined with `GroupedProjection.withGroup` of
    * the returned `GroupedProjection`. The default settings for the window is defined in configuration
    * section `pekko.projection.grouped`.
    *
-   * Compared to [[SlickProjection.groupedWithin]] the [[Handler]] is not storing the projected result in the
+   * Compared to [[SlickProjection.groupedWithin]] the `Handler` is not storing the projected result in the
    * database, but is integrating with something else.
    *
    * It stores the offset in  a relational database table using Slick immediately after the `handler` has
@@ -326,7 +326,7 @@ object SlickProjection {
   }
 
   /**
-   * Create a [[pekko.projection.Projection]] with a [[FlowWithContext]] as the envelope handler. It has at-least-once processing
+   * Create a [[pekko.projection.Projection]] with a `FlowWithContext` as the envelope handler. It has at-least-once processing
    * semantics.
    *
    * The flow should emit a `Done` element for each completed envelope. The offset of the envelope is carried

--- a/testkit/src/main/scala/org/apache/pekko/projection/testkit/javadsl/TestProjection.scala
+++ b/testkit/src/main/scala/org/apache/pekko/projection/testkit/javadsl/TestProjection.scala
@@ -77,7 +77,7 @@ trait TestProjection[Offset, Envelope] extends Projection[Envelope] {
 
   /**
    * The offset store factory. The offset store has the same lifetime as the Projection. It is instantiated when the
-   * projection is first run and is created with [[newState]].
+   * projection is first run and is created with `newState`.
    */
   def withOffsetStoreFactory(factory: Supplier[TestOffsetStore[Offset]]): TestProjection[Offset, Envelope]
 

--- a/testkit/src/main/scala/org/apache/pekko/projection/testkit/javadsl/TestSourceProvider.scala
+++ b/testkit/src/main/scala/org/apache/pekko/projection/testkit/javadsl/TestSourceProvider.scala
@@ -52,7 +52,7 @@ abstract class TestSourceProvider[Offset, Envelope] extends VerifiableSourceProv
       extractCreationTimeFn: java.util.function.Function[Envelope, Long]): TestSourceProvider[Offset, Envelope]
 
   /**
-   * Allow the [[sourceEvents]] Source to complete or stay open indefinitely.
+   * Allow the `sourceEvents` Source to complete or stay open indefinitely.
    */
   def withAllowCompletion(allowCompletion: Boolean): TestSourceProvider[Offset, Envelope]
 
@@ -66,7 +66,7 @@ abstract class TestSourceProvider[Offset, Envelope] extends VerifiableSourceProv
    * A user-defined function to compare the last offset returned by the offset store with the offset in the source
    * to filter out previously processed offsets.
    *
-   * First parameter: Last offset processed. Second parameter this envelope's offset from [[sourceEvents]].
+   * First parameter: Last offset processed. Second parameter this envelope's offset from `sourceEvents`.
    */
   def withStartSourceFrom(startSourceFromFn: java.util.function.BiFunction[Offset, Offset, java.lang.Boolean])
       : TestSourceProvider[Offset, Envelope]

--- a/testkit/src/main/scala/org/apache/pekko/projection/testkit/scaladsl/TestProjection.scala
+++ b/testkit/src/main/scala/org/apache/pekko/projection/testkit/scaladsl/TestProjection.scala
@@ -74,7 +74,7 @@ trait TestProjection[Offset, Envelope] extends Projection[Envelope] {
 
   /**
    * The offset store factory. The offset store has the same lifetime as the Projection. It is instantiated when the
-   * projection is first run and is created with [[newState]].
+   * projection is first run and is created with `newState`.
    */
   def withOffsetStoreFactory(factory: () => TestOffsetStore[Offset]): TestProjection[Offset, Envelope]
 

--- a/testkit/src/main/scala/org/apache/pekko/projection/testkit/scaladsl/TestSourceProvider.scala
+++ b/testkit/src/main/scala/org/apache/pekko/projection/testkit/scaladsl/TestSourceProvider.scala
@@ -51,7 +51,7 @@ trait TestSourceProvider[Offset, Envelope] extends VerifiableSourceProvider[Offs
   def withExtractCreationTimeFunction(extractCreationTimeFn: Envelope => Long): TestSourceProvider[Offset, Envelope]
 
   /**
-   * Allow the [[sourceEvents]] Source to complete or stay open indefinitely.
+   * Allow the `sourceEvents` Source to complete or stay open indefinitely.
    */
   def withAllowCompletion(allowCompletion: Boolean): TestSourceProvider[Offset, Envelope]
 
@@ -64,7 +64,7 @@ trait TestSourceProvider[Offset, Envelope] extends VerifiableSourceProvider[Offs
    * A user-defined function to compare the last offset returned by the offset store with the offset in the source
    * to filter out previously processed offsets.
    *
-   * First parameter: Last offset processed. Second parameter this envelope's offset from [[sourceEvents]].
+   * First parameter: Last offset processed. Second parameter this envelope's offset from `sourceEvents`.
    */
   def withStartSourceFrom(startSourceFromFn: (Offset, Offset) => Boolean): TestSourceProvider[Offset, Envelope]
 }


### PR DESCRIPTION
### Motivation
The project had scaladoc warnings about unresolvable links, ambiguous overloads, and incorrect type references across multiple subprojects (core, jdbc, r2dbc, cassandra, slick, kafka, grpc, testkit).

### Modification
- Replace unresolvable `[[...]]` links with backtick-quoted code for external types (e.g., `FlowWithContext`, `Connection`, `TimestampOffset`, `ActorSystem`)
- Fix unresolvable method references (e.g., `AtLeastOnceProjection.withSaveOffset`, `GroupedProjection.withGroup`, `JdbcHandler.process()`)
- Resolve ambiguous overload links using backtick-quoted code (e.g., `Replication.grpcReplication`, `R2dbcProjection.atLeastOnce`)
- Fix invalid parameter references (e.g., `[[handler]]`, `[[sourceEvents]]`, `[[newState]]`)

### Result
All scaladoc warnings are resolved. `sbt doc` completes with 0 warnings across all subprojects.

### Tests
- [x] `sbt clean doc` completes with 0 warnings across core, jdbc, r2dbc, cassandra, slick, kafka, grpc, testkit
- [x] No functional changes, documentation only

### References
None - scaladoc cleanup