### PR TITLE
Normalize UTF-8 XML encoding declarations

### DIFF
--- a/cassandra-test/src/test/resources/logback-test.xml
+++ b/cassandra-test/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!-- Silence initial setup logging from Logback -->
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/core-test/src/test/resources/logback-test.xml
+++ b/core-test/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!-- Silence initial setup logging from Logback -->
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/eventsourced/src/test/resources/logback-test.xml
+++ b/eventsourced/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
   <!-- Silence initial setup logging from Logback -->
   <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/jdbc-int-test/src/test/resources/logback-test.xml
+++ b/jdbc-int-test/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- Silence initial setup logging from Logback -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/jdbc/src/test/resources/logback-test.xml
+++ b/jdbc/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- Silence initial setup logging from Logback -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/r2dbc-int-test/src/test/resources/logback-test.xml
+++ b/r2dbc-int-test/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">

--- a/slick-int-test/src/test/resources/logback-test.xml
+++ b/slick-int-test/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- Silence initial setup logging from Logback -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/slick/src/test/resources/logback-test.xml
+++ b/slick/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- Silence initial setup logging from Logback -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />

--- a/testkit/src/test/resources/logback-test.xml
+++ b/testkit/src/test/resources/logback-test.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <!-- Silence initial setup logging from Logback -->
     <statusListener class="ch.qos.logback.core.status.NopStatusListener" />


### PR DESCRIPTION
Summary: Normalize lowercase XML encoding declarations to UTF-8 in test resources. Verification: ran formatting, XML validation, git diff --check, and residual exact utf-8 literal search.