### PR TITLE
increase cassandra test timeout

### DIFF
--- a/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
+++ b/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
@@ -58,5 +58,6 @@ object ContainerSessionProvider {
     else
       """
       pekko.projection.cassandra.session-config.session-provider = "org.apache.pekko.projection.cassandra.ContainerSessionProvider"
+      datastax-java-driver.basic.request.timeout = 10 seconds
       """
 }


### PR DESCRIPTION
we have a lot timeouts in tests due to 2sec default for timeouts in the cassandra driver

eg https://github.com/apache/pekko-projection/actions/runs/30248912568/job/89922177187

```
[error] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest failed: java.util.concurrent.ExecutionException: com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S, took 6.684s
[error]     at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
[error]     at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
[error]     at scala.concurrent.impl.FutureConvertersImpl$CF.super$get(FutureConvertersImpl.scala:89)
[error]     at scala.concurrent.impl.FutureConvertersImpl$CF.$anonfun$get$2(FutureConvertersImpl.scala:89)
[error]     at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:62)
[error]     at scala.concurrent.impl.FutureConvertersImpl$CF.get(FutureConvertersImpl.scala:89)
[error]     at org.apache.pekko.projection.cassandra.CassandraProjectionTest.teardown(CassandraProjectionTest.java:102)
[error] Caused by: com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S
[error]     at com.datastax.oss.driver.internal.core.cql.CqlRequestHandler.lambda$scheduleTimeout$1(CqlRequestHandler.java:224)
```