### PR TITLE
cassandra integration test issues

### DIFF
--- a/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
+++ b/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
@@ -281,6 +281,7 @@ public class CassandraProjectionTest {
           assertEquals("fail on 4", error.getMessage());
         });
 
+    assertEquals("abc|def|ghi|", str.toString());
     assertStoredOffset(projectionId, 3L);
 
     // re-run projection without failing function
@@ -360,6 +361,7 @@ public class CassandraProjectionTest {
           assertEquals("fail on 4", error.getMessage());
         });
 
+    assertEquals("abc|def|ghi|", str.toString());
     assertStoredOffset(projectionId, 4L);
 
     // re-run projection without failing function

--- a/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
+++ b/cassandra-test/src/test/java/org/apache/pekko/projection/cassandra/CassandraProjectionTest.java
@@ -14,7 +14,6 @@
 package org.apache.pekko.projection.cassandra;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.time.Duration;
 import java.util.List;
@@ -48,12 +47,14 @@ import org.apache.pekko.projection.testkit.javadsl.TestSourceProvider;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSession;
 import org.apache.pekko.stream.connectors.cassandra.javadsl.CassandraSessionRegistry;
 import org.apache.pekko.stream.javadsl.Source;
+import org.apache.pekko.stream.testkit.TestSubscriber;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import scala.concurrent.Await;
 import scala.jdk.javaapi.FutureConverters;
+import scala.util.Either;
 
 @ExtendWith(LogCapturingExtension.class)
 public class CassandraProjectionTest {
@@ -191,6 +192,16 @@ public class CassandraProjectionTest {
             });
   }
 
+  @SuppressWarnings({"unchecked", "deprecation"})
+  private Throwable eventuallyExpectError(TestSubscriber.Probe<?> sinkProbe) {
+    while (true) {
+      Either<Throwable, ?> result = (Either<Throwable, ?>) sinkProbe.expectNextOrError();
+      if (result.isLeft()) {
+        return result.left().get();
+      }
+    }
+  }
+
   private Handler<Envelope> concatHandler(StringBuffer str) {
     return Handler.fromFunction(
         envelope -> {
@@ -262,16 +273,13 @@ public class CassandraProjectionTest {
                 projectionId, sourceProvider(entityId), () -> concatHandlerFail4(str))
             .withSaveOffset(1, Duration.ZERO);
 
-    try {
-      projectionTestKit.run(
-          projection,
-          () -> {
-            assertEquals("abc|def|ghi|", str.toString());
-          });
-      fail("Expected exception");
-    } catch (RuntimeException e) {
-      assertEquals("fail on 4", e.getMessage());
-    }
+    projectionTestKit.runWithTestSink(
+        projection,
+        sinkProbe -> {
+          sinkProbe.request(1000);
+          Throwable error = eventuallyExpectError(sinkProbe);
+          assertEquals("fail on 4", error.getMessage());
+        });
 
     assertStoredOffset(projectionId, 3L);
 
@@ -344,16 +352,13 @@ public class CassandraProjectionTest {
         CassandraProjection.atMostOnce(
             projectionId, sourceProvider(entityId), () -> concatHandlerFail4(str));
 
-    try {
-      projectionTestKit.run(
-          projection,
-          () -> {
-            assertEquals("abc|def|ghi|", str.toString());
-          });
-      fail("Expected exception");
-    } catch (RuntimeException e) {
-      assertEquals("fail on 4", e.getMessage());
-    }
+    projectionTestKit.runWithTestSink(
+        projection,
+        sinkProbe -> {
+          sinkProbe.request(1000);
+          Throwable error = eventuallyExpectError(sinkProbe);
+          assertEquals("fail on 4", error.getMessage());
+        });
 
     assertStoredOffset(projectionId, 4L);
 

--- a/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
+++ b/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
@@ -19,20 +19,19 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Try
 
-import com.typesafe.config.{ Config => TypesafeConfig }
-import org.apache.pekko.actor.ClassicActorSystemProvider
+import org.apache.pekko.actor.ActorSystem
 import org.apache.pekko.stream.connectors.cassandra.CqlSessionProvider
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint
+import com.typesafe.config.Config
 import org.testcontainers.cassandra.CassandraContainer
 import org.testcontainers.utility.DockerImageName
 
 /**
  * Use testcontainers to lazily provide a single CqlSession for all Cassandra tests
  */
-final class ContainerSessionProvider(system: ClassicActorSystemProvider, sessionConfig: TypesafeConfig)
-    extends CqlSessionProvider {
+final class ContainerSessionProvider(system: ActorSystem, sessionConfig: Config) extends CqlSessionProvider {
   import ContainerSessionProvider._
 
   private val driverConfig = CqlSessionProvider.driverConfig(system, sessionConfig)

--- a/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
+++ b/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
@@ -19,7 +19,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Try
 
-import com.typesafe.config.{Config => TypesafeConfig}
+import com.typesafe.config.{ Config => TypesafeConfig }
 import org.apache.pekko.actor.ClassicActorSystemProvider
 import org.apache.pekko.stream.connectors.cassandra.CqlSessionProvider
 import com.datastax.oss.driver.api.core.CqlSession

--- a/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
+++ b/cassandra-test/src/test/scala/org/apache/pekko/projection/cassandra/ContainerSessionProvider.scala
@@ -19,8 +19,11 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.util.Try
 
+import com.typesafe.config.{Config => TypesafeConfig}
+import org.apache.pekko.actor.ClassicActorSystemProvider
 import org.apache.pekko.stream.connectors.cassandra.CqlSessionProvider
 import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.internal.core.config.typesafe.DefaultDriverConfigLoader
 import com.datastax.oss.driver.internal.core.metadata.DefaultEndPoint
 import org.testcontainers.cassandra.CassandraContainer
 import org.testcontainers.utility.DockerImageName
@@ -28,14 +31,18 @@ import org.testcontainers.utility.DockerImageName
 /**
  * Use testcontainers to lazily provide a single CqlSession for all Cassandra tests
  */
-final class ContainerSessionProvider extends CqlSessionProvider {
+final class ContainerSessionProvider(system: ClassicActorSystemProvider, sessionConfig: TypesafeConfig)
+    extends CqlSessionProvider {
   import ContainerSessionProvider._
+
+  private val driverConfig = CqlSessionProvider.driverConfig(system, sessionConfig)
 
   override def connect()(implicit ec: ExecutionContext): Future[CqlSession] = started.map { _ =>
     CqlSession.builder
       .addContactEndPoint(new DefaultEndPoint(InetSocketAddress
         .createUnresolved(container.getHost, container.getFirstMappedPort.intValue())))
       .withLocalDatacenter("datacenter1")
+      .withConfigLoader(new DefaultDriverConfigLoader(() => driverConfig))
       .build()
   }
 }


### PR DESCRIPTION
Continuing issues happening regularly but not all the time

```
[info] [2026-07-28 15:25:34,100] [INFO] [org.apache.pekko.actor.testkit.typed.javadsl.LogCapturingExtension] [] [pool-29-thread-8] - Logging started for test [CassandraProjectionTest: atMostOnceShouldRestartFromNextOffset] MDC: {}
  <-- [CassandraProjectionTest: atMostOnceShouldRestartFromNextOffset] End of log messages of test that failed with Expected exception
  [error] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest.atMostOnceShouldRestartFromNextOffset failed: org.opentest4j.AssertionFailedError: Expected exception, took 0.209s
  [error]     at org.apache.pekko.projection.cassandra.CassandraProjectionTest.atMostOnceShouldRestartFromNextOffset(CassandraProjectionTest.java:353)
  [info] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest#atLeastOnceShouldStoreOffset() started
  [info] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest#atMostOnceShouldStoreOffset() started
  [info] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest#atLeastOnceShouldRestartFromPreviousOffset() started
  [info] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest#actorHandlerShouldStartStopActor() started
  [info] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest#groupedShouldStoreOffset() started
  [error] Test org.apache.pekko.projection.cassandra.CassandraProjectionTest failed: java.util.concurrent.ExecutionException: com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S, took 7.286s
  [error]     at java.util.concurrent.CompletableFuture.reportGet(CompletableFuture.java:396)
  [error]     at java.util.concurrent.CompletableFuture.get(CompletableFuture.java:2096)
  [error]     at scala.concurrent.impl.FutureConvertersImpl$CF.super$get(FutureConvertersImpl.scala:89)
  [error]     at scala.concurrent.impl.FutureConvertersImpl$CF.$anonfun$get$2(FutureConvertersImpl.scala:89)
  [error]     at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:62)
  [error]     at scala.concurrent.impl.FutureConvertersImpl$CF.get(FutureConvertersImpl.scala:89)
  [error]     at org.apache.pekko.projection.cassandra.CassandraProjecraProjectionTest.java:102)
```