### PR TITLE
fix leaked Statement/ResultSet in JdbcSessionUtil.tryWithResource

### DIFF
--- a/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcSessionUtil.scala
+++ b/jdbc/src/main/scala/org/apache/pekko/projection/jdbc/internal/JdbcSessionUtil.scala
@@ -76,11 +76,13 @@ private[projection] object JdbcSessionUtil {
    * The AutoCloseable is closed after usage. If an exception is thrown when closing it, it will be ignored.
    */
   def tryWithResource[T, C <: AutoCloseable](closeable: => C)(func: C => T): T = {
+    // must be evaluated only once, otherwise the resource passed to `func` is not the one that is closed
+    val resource = closeable
     try {
-      func(closeable)
+      func(resource)
     } finally {
       try {
-        closeable.close()
+        resource.close()
       } catch {
         // if we get the result, but fail to close the statement, we just proceed
         // on connection close we will get another chance to close it

--- a/jdbc/src/test/scala/org/apache/pekko/projection/jdbc/internal/JdbcSessionUtilSpec.scala
+++ b/jdbc/src/test/scala/org/apache/pekko/projection/jdbc/internal/JdbcSessionUtilSpec.scala
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.pekko.projection.jdbc.internal
+
+import java.sql.SQLException
+
+import scala.collection.mutable.ListBuffer
+
+import org.apache.pekko
+import pekko.actor.testkit.typed.scaladsl.LogCapturing
+import org.scalatest.TestSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpecLike
+
+class JdbcSessionUtilSpec extends TestSuite with Matchers with AnyWordSpecLike with LogCapturing {
+
+  private class TestResource(onClose: () => Unit = () => ()) extends AutoCloseable {
+    var closeCount = 0
+    override def close(): Unit = {
+      closeCount += 1
+      onClose()
+    }
+  }
+
+  /** Records every resource that gets created, so that we can detect a resource that is created but never closed. */
+  private class TestResourceFactory(onClose: () => Unit = () => ()) {
+    val created: ListBuffer[TestResource] = ListBuffer.empty
+    def newResource(): TestResource = {
+      val resource = new TestResource(onClose)
+      created += resource
+      resource
+    }
+  }
+
+  "JdbcSessionUtil.tryWithResource" must {
+
+    "create the resource only once and close the very same instance" in {
+      val factory = new TestResourceFactory
+      var passedToFunc: TestResource = null
+
+      val result =
+        JdbcSessionUtil.tryWithResource(factory.newResource()) { resource =>
+          passedToFunc = resource
+          resource.closeCount shouldBe 0
+          "result"
+        }
+
+      result shouldBe "result"
+      factory.created.toList should have size 1
+      passedToFunc should be theSameInstanceAs factory.created.head
+      passedToFunc.closeCount shouldBe 1
+    }
+
+    "close the resource passed to the function when the function throws" in {
+      val factory = new TestResourceFactory
+
+      val ex = intercept[RuntimeException] {
+        JdbcSessionUtil.tryWithResource(factory.newResource()) { _ =>
+          throw new RuntimeException("boom")
+        }
+      }
+
+      ex.getMessage shouldBe "boom"
+      factory.created.toList should have size 1
+      factory.created.head.closeCount shouldBe 1
+    }
+
+    "ignore a SQLException thrown when closing the resource" in {
+      val factory = new TestResourceFactory(() => throw new SQLException("can't close"))
+
+      JdbcSessionUtil.tryWithResource(factory.newResource())(_ => "result") shouldBe "result"
+
+      factory.created.toList should have size 1
+      factory.created.head.closeCount shouldBe 1
+    }
+  }
+}

--- a/jdbc/src/test/scala/org/apache/pekko/projection/jdbc/internal/JdbcSessionUtilSpec.scala
+++ b/jdbc/src/test/scala/org/apache/pekko/projection/jdbc/internal/JdbcSessionUtilSpec.scala
@@ -62,7 +62,7 @@ class JdbcSessionUtilSpec extends TestSuite with Matchers with AnyWordSpecLike w
 
       result shouldBe "result"
       factory.created.toList should have size 1
-      passedToFunc should be theSameInstanceAs factory.created.head
+      assert(passedToFunc eq factory.created.head)
       passedToFunc.closeCount shouldBe 1
     }
 


### PR DESCRIPTION
### Motivation
`JdbcSessionUtil.tryWithResource` takes the resource as a by-name parameter and evaluates it **twice**: once when calling `func`, and once again in the `finally` block.

```scala
def tryWithResource[T, C <: AutoCloseable](closeable: => C)(func: C => T): T = {
  try { func(closeable) }          // evaluates the by-name arg -> resource #1
  finally { try closeable.close()  // evaluates it AGAIN -> resource #2, closes #2
```

So the resource handed to `func` is never closed, and a second one is created just to be closed. Consequences:

* `JdbcOffsetStore` (lines 69, 80, 98, 114, 182, 200, 240, 281, 301) and `SlickOffsetStore` (lines 169, 176, 187, 193) leak a `Statement`/`PreparedStatement` on every call. When the `JdbcSession` is backed by a connection pool (connection returned to the pool rather than physically closed) these accumulate on the physical connection and can exhaust server-side cursors.
* `tryWithResource(stmt.executeQuery())` in `JdbcOffsetStore.readOffset` and `readManagementState` executes the query a second time and leaks the first `ResultSet`.

### Modification
Evaluate the by-name parameter once into a local val, and use that instance both for `func` and for `close()`.

### Result
The resource passed to `func` is the one that gets closed, no extra resource is created, and each query is executed once.

### Tests
- New `JdbcSessionUtilSpec` asserts that exactly one resource is created and that the instance passed to the function is the one closed (also on function failure, and when `close()` throws `SQLException`). All 3 cases fail before the fix.
- `sbt "jdbc/test"` - 31 passed
- `sbt "jdbc/mimaReportBinaryIssues"` - success
- `sbt checkCodeStyle` - success
- `sbt headerCreateAll` - header added to the new spec

### References
None - found during a resource-leak audit of the main sources