### PR TITLE
cancel in-progress replay streams when FilterStage stops

### DIFF
--- a/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/internal/FilterStageSpec.scala
+++ b/grpc-test/src/test/scala/org/apache/pekko/projection/grpc/internal/FilterStageSpec.scala
@@ -125,6 +125,9 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
         }
       }
 
+    def currentEventsByPersistenceIdQuery: CurrentEventsByPersistenceIdTypedQuery =
+      testCurrentEventsByPersistenceIdQuery(allEnvelopes)
+
     private val envPublisherPromise = Promise[TestPublisher.Probe[EventEnvelope[Any]]]()
     private val envSource: Source[EventEnvelope[Any], ?] =
       TestSource()
@@ -137,7 +140,7 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
             entityType,
             0 until persistence.numberOfSlices,
             initFilter,
-            testCurrentEventsByPersistenceIdQuery(allEnvelopes),
+            currentEventsByPersistenceIdQuery,
             producerFilter = initProducerFilter,
             replayParallelism = producerSettings.replayParallelism))
         .join(Flow.fromSinkAndSource(Sink.ignore, envSource))
@@ -327,6 +330,37 @@ class FilterStageSpec extends ScalaTestWithActorTestKit("""
       outProbe.expectNoMessage()
 
       envPublisher.sendComplete()
+    }
+
+    "cancel replay streams that are still in progress when stopped" in new Setup {
+      val replayStarted = createTestProbe[String]()
+      val replayCancelled = createTestProbe[String]()
+
+      override def currentEventsByPersistenceIdQuery: CurrentEventsByPersistenceIdTypedQuery =
+        new CurrentEventsByPersistenceIdTypedQuery {
+          override def currentEventsByPersistenceIdTyped[Event](
+              persistenceId: String,
+              fromSequenceNr: Long,
+              toSequenceNr: Long): Source[EventEnvelope[Event], NotUsed] =
+            // never emits, so that the replay is still in progress when the stage is stopped
+            Source
+              .never[EventEnvelope[Event]]
+              .watchTermination { (_, terminated) =>
+                replayStarted.ref ! persistenceId
+                terminated.onComplete(_ => replayCancelled.ref ! persistenceId)(system.executionContext)
+                NotUsed
+              }
+        }
+
+      val pid = PersistenceId(entityType, "b").id
+      outProbe.request(10)
+      inPublisher.sendNext(StreamIn(StreamIn.Message.Replay(ReplayReq(List(PersistenceIdSeqNr(pid, 1L))))))
+
+      replayStarted.expectMessage(pid)
+      replayCancelled.expectNoMessage()
+
+      outProbe.cancel()
+      replayCancelled.expectMessage(pid)
     }
 
   }

--- a/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/FilterStage.scala
+++ b/grpc/src/main/scala/org/apache/pekko/projection/grpc/internal/FilterStage.scala
@@ -184,6 +184,12 @@ import org.slf4j.LoggerFactory
         initFilter = Nil // for GC
       }
 
+      override def postStop(): Unit = {
+        // replay streams that are still in progress would otherwise be leaked
+        replayInProgress.valuesIterator.foreach(_.queue.cancel())
+        replayInProgress = Map.empty
+      }
+
       private def onReplay(replayEnv: ReplayEnvelope): Unit = {
         def replayCompleted(): Unit = {
           replayInProgress -= replayEnv.persistenceId


### PR DESCRIPTION
### Motivation
`FilterStage` materialises a `currentEventsByPersistenceIdTyped` query per replay with `Sink.queue()` and keeps it in `replayInProgress`:

```scala
val queue = currentEventsByPersistenceIdQuery
  .currentEventsByPersistenceIdTyped[Any](pid, fromSeqNr, Long.MaxValue)
  .runWith(Sink.queue())(materializer)
replayInProgress = replayInProgress.updated(pid, ReplaySession(fromSeqNr, queue))
```

`queue.cancel()` is only called when a replay is replaced by a newer replay for the same persistenceId. There is no `postStop`, so when the stage completes or fails (`failStage` from the replay callback, or the consumer cancelling the gRPC stream) every replay still in progress - up to `replayParallelism` per stream - stays materialised with an un-pulled `SinkQueue`, keeping the query stream and the resources it holds, such as a database connection, alive indefinitely.

### Modification
Cancel the queues of all replays still in `replayInProgress` from `postStop`.

### Result
Replay streams are cancelled when the stage stops, instead of being leaked.

### Tests
- New `FilterStageSpec` case "cancel replay streams that are still in progress when stopped": starts a replay backed by a source that never emits, stops the stage, and expects the replay source to be cancelled. It fails without the fix (the source is never cancelled).
- `sbt "grpc-test/Test/testOnly *FilterStageSpec"` - 9 passed
- `sbt checkCodeStyle` - success
- MiMa not run - `MimaPlugin` is disabled for the `grpc` module in `build.sbt`; the change only adds a method to an anonymous `GraphStageLogic` inside `@InternalApi` `FilterStage`.

### References
None - found during a resource-leak audit of the main sources