### PR TITLE
only run R2dbcOffsetStore delete task while the projection is running

### DIFF
--- a/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/r2dbc-int-test/src/test/scala/org/apache/pekko/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -18,8 +18,10 @@ import java.time.{ Duration => JDuration }
 import java.util.UUID
 
 import scala.concurrent.Future
+import scala.concurrent.duration._
 
 import org.apache.pekko
+import pekko.Done
 import pekko.actor.testkit.typed.scaladsl.LogCapturing
 import pekko.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
 import pekko.actor.typed.ActorSystem
@@ -963,6 +965,7 @@ class R2dbcTimestampOffsetStoreSpec
           .withDeleteInterval(JDuration.ofMillis(500))
       import deleteSettings._
       val offsetStore = createOffsetStore(projectionId, deleteSettings)
+      offsetStore.startDeleteTask()
 
       val startTime = TestClock.nowMicros().instant()
       log.debug("Start time [{}]", startTime)
@@ -992,6 +995,41 @@ class R2dbcTimestampOffsetStoreSpec
         offsetStore.readOffset().futureValue // this will load from database
         offsetStore.getState().byPid.keySet shouldBe Set(p3)
       }
+    }
+
+    "stop the periodic delete of old records when the projection is stopped" in {
+      val projectionId = genRandomProjectionId()
+      val deleteInterval = JDuration.ofMillis(100)
+      val deleteSettings = settings.withDeleteInterval(deleteInterval)
+      val deleteProbe = createTestProbe[Done]()
+      val offsetStore =
+        new R2dbcOffsetStore(
+          projectionId,
+          Some(new TestTimestampSourceProvider(0, persistenceExt.numberOfSlices - 1, clock)),
+          system,
+          deleteSettings,
+          r2dbcExecutor) {
+          override def deleteOldTimestampOffsets(): Future[Long] = {
+            deleteProbe.ref ! Done
+            super.deleteOldTimestampOffsets()
+          }
+        }
+
+      val startTime = System.nanoTime()
+      offsetStore.startDeleteTask()
+      offsetStore.startDeleteTask() // idempotent, only one task is scheduled
+      deleteProbe.receiveMessages(5)
+      // 5 ticks take 5 delete intervals with one task, but only 3 with two tasks
+      (System.nanoTime() - startTime).nanos should be >= (deleteInterval.toMillis * 4).millis
+
+      // cancelled right after a tick, so the next tick would not be due until one delete interval later
+      offsetStore.stopDeleteTask()
+      deleteProbe.expectNoMessage(deleteInterval.toMillis.millis * 10)
+
+      // started again when a stopped projection is started again
+      offsetStore.startDeleteTask()
+      deleteProbe.receiveMessages(2)
+      offsetStore.stopDeleteTask()
     }
 
     "set offset" in {

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcOffsetStore.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcOffsetStore.scala
@@ -27,6 +27,7 @@ import scala.concurrent.Future
 
 import org.apache.pekko
 import pekko.Done
+import pekko.actor.Cancellable
 import pekko.actor.typed.ActorSystem
 import pekko.actor.typed.scaladsl.LoggerOps
 import pekko.annotation.InternalApi
@@ -319,11 +320,32 @@ private[projection] class R2dbcOffsetStore(
   // To avoid delete requests when no new offsets have been stored since previous delete
   private val idle = new AtomicBoolean(false)
 
-  system.scheduler.scheduleWithFixedDelay(
-    settings.deleteInterval,
-    settings.deleteInterval,
-    () => deleteOldTimestampOffsets(),
-    system.executionContext)
+  // Scheduled deletes of old timestamp offsets are only running while the projection is running, otherwise the
+  // scheduled task would keep this offset store (and everything it references) alive for the lifetime of the
+  // ActorSystem, also for projections that have been stopped.
+  private val deleteTask = new AtomicReference(Option.empty[Cancellable])
+
+  /**
+   * Start the periodic deletion of old timestamp offsets. Called when the projection is started. Idempotent, and can
+   * be called again after `stopDeleteTask`, such as when a stopped projection is started again.
+   */
+  def startDeleteTask(): Unit = {
+    if (deleteTask.get().isEmpty) {
+      val task = system.scheduler.scheduleWithFixedDelay(
+        settings.deleteInterval,
+        settings.deleteInterval,
+        () => deleteOldTimestampOffsets(),
+        system.executionContext)
+      if (!deleteTask.compareAndSet(None, Some(task)))
+        task.cancel() // concurrent start, keep the already registered task
+    }
+  }
+
+  /**
+   * Cancel the periodic deletion of old timestamp offsets. Called when the projection is stopped.
+   */
+  def stopDeleteTask(): Unit =
+    deleteTask.getAndSet(None).foreach(_.cancel())
 
   private def timestampOffsetBySlicesSourceProvider: BySlicesSourceProvider =
     sourceProvider match {

--- a/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcProjectionImpl.scala
+++ b/r2dbc/src/main/scala/org/apache/pekko/projection/r2dbc/internal/R2dbcProjectionImpl.scala
@@ -716,9 +716,13 @@ private[projection] class R2dbcProjectionImpl[Offset, Envelope](
       extends RunningProjection
       with RunningProjectionManagement[Offset] {
 
+    // the periodic deletes of old timestamp offsets are only running while the projection is running
+    offsetStore.startDeleteTask()
+
     private val streamDone = source.run()
 
     override def stop(): Future[Done] = {
+      offsetStore.stopDeleteTask()
       projectionState.killSwitch.shutdown()
       // if the handler is retrying it will be aborted by this,
       // otherwise the stream would not be completed by the killSwitch until after all retries


### PR DESCRIPTION
### Motivation
`R2dbcOffsetStore` scheduled `deleteOldTimestampOffsets` with a fixed delay in its constructor and discarded the returned `Cancellable`:

```scala
system.scheduler.scheduleWithFixedDelay(
  settings.deleteInterval, settings.deleteInterval,
  () => deleteOldTimestampOffsets(), system.executionContext)
```

The store is created eagerly by every `R2dbcProjection` factory method (`R2dbcProjectionImpl.createOffsetStore`), so the task starts before the projection runs, and nothing ever cancels it. It keeps firing every `delete-interval` (`1 minute` by default) for the lifetime of the `ActorSystem`, also after the projection has been stopped, and it keeps the offset store, its source provider and its `R2dbcExecutor` reachable, so each stopped projection is retained. This adds up when projections are stopped and started, such as on ShardedDaemonProcess rebalance.

### Modification
Keep the `Cancellable` and expose `startDeleteTask()`/`stopDeleteTask()` on the offset store. `R2dbcRunningProjection` starts the task when it is created and cancels it in `stop()`, so the deletes run while the projection is running, and a projection that is stopped and started again (`ProjectionBehavior` does this for the offset management commands) gets the task back.

### Result
No scheduled task, and no retained offset store, for a projection that has been stopped or that was never run.

One behaviour note: the deletes are not scheduled for the `ProjectionTestKit` path, which runs `mappedSource()` without a `RunningProjection`. Tests that exercise deletion call the offset store directly, and `R2dbcTimestampOffsetStoreSpec` "periodically delete old records" now starts the task explicitly.

### Tests
- New `R2dbcTimestampOffsetStoreSpec` case "stop the periodic delete of old records when the projection is stopped": counts the scheduled delete ticks through a probe, asserts they stop after `stopDeleteTask()` and resume after a later `startDeleteTask()`. It fails if `stopDeleteTask()` does not cancel (verified by neutering the cancel).
- `sbt "r2dbc-int-test/Test/testOnly *R2dbcTimestampOffsetStoreSpec"` - 21 passed
- `sbt "r2dbc-int-test/test"` - 116 passed. `RuntimePluginConfigSpec` aborts in my environment with `database "database1" does not exist`; it aborts identically on the unmodified main branch, so it is unrelated to this change.
- `sbt "r2dbc/mimaReportBinaryIssues"` - success
- `sbt checkCodeStyle` - success

### References
None - found during a resource-leak audit of the main sources