### PR TITLE
create the Kafka metadata client when the source is materialized

### DIFF
--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImpl.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImpl.scala
@@ -94,23 +94,30 @@ import org.apache.kafka.common.record.TimestampType
         })
 
   override def source(readOffsets: ReadOffsets): Future[Source[ConsumerRecord[K, V], NotUsed]] = {
-    // get the total number of partitions to configure the `breadth` parameter, or we could just use a really large
-    // number.  i don't think using a large number would present a problem.
-    val metadataClient = metadataClientFactory()
-    val numPartitionsF = metadataClient.numPartitions(topics)
-    numPartitionsF.failed.foreach(_ => metadataClient.stop())
-    numPartitionsF.map { numPartitions =>
-      _source(readOffsets, numPartitions, metadataClient)
-        .mapMaterializedValue { m =>
-          control = Some(m)
-          m
+    // The metadata client is created when the source is materialized, and stopped when the stream terminates.
+    // Creating it eagerly here would leak the client, and its Kafka consumer actor, when the returned source is
+    // never materialized, such as when the projection is stopped while it is starting up.
+    val source =
+      Source.lazyFutureSource[ConsumerRecord[K, V], NotUsed] { () =>
+        // get the total number of partitions to configure the `breadth` parameter, or we could just use a really large
+        // number.  i don't think using a large number would present a problem.
+        val metadataClient = metadataClientFactory()
+        val numPartitionsF = metadataClient.numPartitions(topics)
+        numPartitionsF.failed.foreach(_ => metadataClient.stop())
+        numPartitionsF.map { numPartitions =>
+          _source(readOffsets, numPartitions, metadataClient)
+            .mapMaterializedValue { m =>
+              control = Some(m)
+              m
+            }
+            .watchTermination(Keep.right)
+            .mapMaterializedValue { terminated =>
+              terminated.onComplete(_ => metadataClient.stop())
+              NotUsed
+            }
         }
-        .watchTermination(Keep.right)
-        .mapMaterializedValue { terminated =>
-          terminated.onComplete(_ => metadataClient.stop())
-          NotUsed
-        }
-    }
+      }
+    Future.successful(source.mapMaterializedValue(_ => NotUsed))
   }
 
   override def source(readOffsets: Supplier[CompletionStage[Optional[MergeableOffset[JLong]]]])

--- a/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImpl.scala
+++ b/kafka/src/main/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImpl.scala
@@ -100,7 +100,7 @@ import org.apache.kafka.common.record.TimestampType
     val source =
       Source.lazyFutureSource[ConsumerRecord[K, V], NotUsed] { () =>
         // get the total number of partitions to configure the `breadth` parameter, or we could just use a really large
-        // number.  i don't think using a large number would present a problem.
+        // number. I don't think using a large number would present a problem.
         val metadataClient = metadataClientFactory()
         val numPartitionsF = metadataClient.numPartitions(topics)
         numPartitionsF.failed.foreach(_ => metadataClient.stop())

--- a/kafka/src/test/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImplSpec.scala
+++ b/kafka/src/test/scala/org/apache/pekko/projection/kafka/internal/KafkaSourceProviderImplSpec.scala
@@ -13,6 +13,8 @@
 
 package org.apache.pekko.projection.kafka.internal
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -28,6 +30,7 @@ import pekko.projection.ProjectionId
 import pekko.projection.scaladsl.Handler
 import pekko.projection.testkit.scaladsl.ProjectionTestKit
 import pekko.projection.testkit.scaladsl.TestProjection
+import pekko.stream.scaladsl.Sink
 import pekko.stream.scaladsl.Source
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.TopicPartition
@@ -133,6 +136,54 @@ class KafkaSourceProviderImplSpec extends ScalaTestWithActorTestKit with LogCapt
           records.count(_.partition() == tp0.partition()) shouldBe tp0Expect
           records.count(_.partition() == tp1.partition()) shouldBe 0
         }
+      }
+    }
+
+    "create the metadata client when the source is materialized and stop it when the stream completes" in {
+      val topic = "topic"
+      val partitions = 2
+      val settings = ConsumerSettings(system, new StringDeserializer, new StringDeserializer)
+        .withBootstrapServers("localhost:9092")
+        .withGroupId("group-id")
+
+      val createdClients = new AtomicInteger()
+      val stoppedClients = new AtomicInteger()
+      val metadataClientFactory = () => {
+        createdClients.incrementAndGet()
+        new TestMetadataClientAdapter(partitions) {
+          override def stop(): Unit = stoppedClients.incrementAndGet()
+        }
+      }
+
+      val consumerSource = Source
+        .single(new ConsumerRecord(topic, 0, 0L, "key", "value"))
+        .mapMaterializedValue(_ => Consumer.NoopControl)
+
+      val provider =
+        new KafkaSourceProviderImpl(
+          system,
+          settings,
+          Set(topic),
+          metadataClientFactory,
+          KafkaSourceProviderSettings(system)) {
+          override protected[internal] def _source(
+              readOffsets: () => Future[Option[MergeableOffset[java.lang.Long]]],
+              numPartitions: Int,
+              metadataClient: MetadataClientAdapter): Source[ConsumerRecord[String, String], Consumer.Control] =
+            consumerSource
+        }
+
+      val source = provider.source(() => Future.successful(None)).futureValue
+
+      withClue("checking: no metadata client is created for a source that is not materialized") {
+        createdClients.get() shouldBe 0
+      }
+
+      source.runWith(Sink.ignore).futureValue
+
+      createdClients.get() shouldBe 1
+      eventually {
+        stoppedClients.get() shouldBe 1
       }
     }
   }


### PR DESCRIPTION
### Motivation
`KafkaSourceProviderImpl.source` creates the `MetadataClientAdapter` - and with it a `KafkaConsumerActor` and its Kafka consumer - before returning the source:

```scala
val metadataClient = metadataClientFactory()
val numPartitionsF = metadataClient.numPartitions(topics)
numPartitionsF.failed.foreach(_ => metadataClient.stop())
numPartitionsF.map { numPartitions =>
  _source(readOffsets, numPartitions, metadataClient)
    ...
    .mapMaterializedValue { terminated => terminated.onComplete(_ => metadataClient.stop()); NotUsed }
}
```

It is stopped only when `numPartitions` fails, or when the materialized stream terminates. If the returned source is never materialized - for example when the projection is stopped between `source()` completing and the stream being run, which the restart backoff makes possible on every restart - the client and its consumer actor are never stopped.

### Modification
Create the metadata client inside `Source.lazyFutureSource`, so it is only created when the source is materialized and demand arrives, and is then always stopped by the existing `watchTermination` callback. The `numPartitions` lookup (used for the `flatMapMerge` breadth) moves with it, so a failure now fails the stream instead of the returned future; both end up failing the projection stream, which the restart backoff handles.

### Result
No orphaned metadata client, and no orphaned Kafka consumer actor, for a source that is never materialized.

### Tests
- New `KafkaSourceProviderImplSpec` case: asserts no metadata client is created for a source that is not materialized, and that one is created and then stopped when the stream is run. It fails before the fix (the client is created eagerly).
- `sbt "kafka/test"` - 2 passed
- `sbt "kafka/mimaReportBinaryIssues"` - success
- `sbt checkCodeStyle` - success
- The `kafka-test` integration specs were not run locally (they need Kafka testcontainers); they exercise this path via `Source.futureSource(provider.source(...))` and are covered by the CI Kafka integration jobs.

### References
None - found during a resource-leak audit of the main sources